### PR TITLE
Configure Supabase client with project credentials

### DIFF
--- a/supabaseClient.js
+++ b/supabaseClient.js
@@ -1,11 +1,4 @@
-import { createClient } from '@supabase/supabase-js';
-
-// It's best practice to keep sensitive keys in environment variables.
-// For demonstration, your keys are shown directly, but consider using process.env for production.
-
-const SUPABASE_URL = 'https://gxewpstvuoofdqanhjzi.supabase.co';
-const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Imd4ZXdwc3R2dW9vZmRxYW5oanppIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTQwNjM1NzUsImV4cCI6MjA2OTYzOTU3NX0._W88NSjDmv4dXoE701SKMQ60J8D3DTCcRX5VVRJYr_E';
-
-const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
-
-export default supabase;
+import { createClient } from '@supabase/supabase-js'
+const supabaseUrl = 'https://gxewpstvuoofdqanhjzi.supabase.co'
+const supabaseAnonKey = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJ1Zl6Imd4ZXdwc3R2dW9vZmRxYW5oanppliwicm9sZSI6InFub24iLCJpYXQiOjE3NTQwNjM1NzUsImV4cCI6MjA2OTYzOTU3NX0._W8NSjDmv4dXoE701SKMQ60J8D3DTCCcRX5WRJYr_E'
+export const supabase = createClient(supabaseUrl, supabaseAnonKey)


### PR DESCRIPTION
## Summary
- define Supabase URL and anon key
- export Supabase client using `createClient`

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688e1c26ac8c8329aea25bc939e35e87