### PR TITLE
Add Supabase debug button

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,6 +48,18 @@
       box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
     }
 
+    .test-supabase-button {
+      background-color: #4caf50;
+      color: white;
+      padding: 0.8em 2em;
+      border: none;
+      border-radius: 25px;
+      font-size: 1em;
+      cursor: pointer;
+      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+      margin-top: 1em;
+    }
+
     @media (max-width: 600px) {
       h1 {
         font-size: 1.8em;
@@ -63,5 +75,24 @@
   <h1>🌍 Welcome to The Naturverse™</h1>
   <p>A Magical World of Learning</p>
   <button class="coming-soon-button">Coming Soon</button>
+  <button id="test-supabase" class="test-supabase-button">Test Supabase</button>
+
+  <script type="module">
+    import { supabase } from './supabaseClient.js'
+
+    const button = document.getElementById('test-supabase')
+    button.addEventListener('click', async () => {
+      const { error } = await supabase.from('test_logs').insert({
+        message: 'Hello from the homepage!',
+        timestamp: new Date().toISOString()
+      })
+
+      if (error) {
+        console.error('Error inserting test row:', error)
+      } else {
+        console.log('Test row inserted successfully')
+      }
+    })
+  </script>
 </body>
 </html>

--- a/supabaseClient.js
+++ b/supabaseClient.js
@@ -1,4 +1,6 @@
-import { createClient } from '@supabase/supabase-js'
+import { createClient } from 'https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.53.0/+esm'
+
 const supabaseUrl = 'https://gxewpstvuoofdqanhjzi.supabase.co'
 const supabaseAnonKey = 'sb_publishable_BDdV5w6oEVsrnwBL5f-zhw_Xdjkm7ip'
+
 export const supabase = createClient(supabaseUrl, supabaseAnonKey)


### PR DESCRIPTION
## Summary
- add temporary Test Supabase button that writes a test row to `test_logs`
- load Supabase client using publishable project URL and key

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_688ffc9241cc8329b57e8f7a64a8953f