### PR TITLE
Add Supabase test button to homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,24 +75,8 @@
   <h1>🌍 Welcome to The Naturverse™</h1>
   <p>A Magical World of Learning</p>
   <button class="coming-soon-button">Coming Soon</button>
-  <button id="test-supabase" class="test-supabase-button">Test Supabase</button>
+  <button class="test-supabase-button">Test Supabase</button>
 
-  <script type="module">
-    import { supabase } from './supabaseClient.js'
-
-    const button = document.getElementById('test-supabase')
-    button.addEventListener('click', async () => {
-      const { error } = await supabase.from('test_logs').insert({
-        message: 'Hello from the homepage!',
-        timestamp: new Date().toISOString()
-      })
-
-      if (error) {
-        console.error('Error inserting test row:', error)
-      } else {
-        console.log('Test row inserted successfully')
-      }
-    })
-  </script>
+  <script type="module" src="supabaseClient.js"></script>
 </body>
 </html>

--- a/supabaseClient.js
+++ b/supabaseClient.js
@@ -4,3 +4,19 @@ const supabaseUrl = 'https://gxewpstvuoofdqanhjzi.supabase.co'
 const supabaseAnonKey = 'sb_publishable_BDdV5w6oEVsrnwBL5f-zhw_Xdjkm7ip'
 
 export const supabase = createClient(supabaseUrl, supabaseAnonKey)
+
+const button = document.querySelector('.test-supabase-button')
+if (button) {
+  button.addEventListener('click', async () => {
+    const { error } = await supabase.from('test_logs').insert({
+      message: 'Hello from the homepage!',
+      timestamp: new Date().toISOString()
+    })
+
+    if (error) {
+      console.error('Error inserting test row:', error)
+    } else {
+      console.log('Test row inserted successfully')
+    }
+  })
+}


### PR DESCRIPTION
## Summary
- Add `Test Supabase` button and load Supabase client script on homepage
- Handle button click in `supabaseClient.js` to insert a row in `test_logs`

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_6890004be7c88329bfea461167461f46