### PR TITLE
Add Supabase test query trigger on button

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,6 +77,6 @@
   <button class="coming-soon-button">Coming Soon</button>
   <button class="test-supabase-button">Test Supabase</button>
 
-  <script type="module" src="supabaseClient.js"></script>
+  <script type="module" src="testSupabase.js"></script>
 </body>
 </html>

--- a/supabaseClient.js
+++ b/supabaseClient.js
@@ -4,19 +4,3 @@ const supabaseUrl = 'https://gxewpstvuoofdqanhjzi.supabase.co'
 const supabaseAnonKey = 'sb_publishable_BDdV5w6oEVsrnwBL5f-zhw_Xdjkm7ip'
 
 export const supabase = createClient(supabaseUrl, supabaseAnonKey)
-
-const button = document.querySelector('.test-supabase-button')
-if (button) {
-  button.addEventListener('click', async () => {
-    const { error } = await supabase.from('test_logs').insert({
-      message: 'Hello from the homepage!',
-      timestamp: new Date().toISOString()
-    })
-
-    if (error) {
-      console.error('Error inserting test row:', error)
-    } else {
-      console.log('Test row inserted successfully')
-    }
-  })
-}

--- a/testSupabase.js
+++ b/testSupabase.js
@@ -1,0 +1,17 @@
+import { supabase } from './supabaseClient.js'
+
+const button = document.querySelector('.test-supabase-button')
+if (button) {
+  button.addEventListener('click', async () => {
+    try {
+      const { data, error } = await supabase.from('test_logs').select('*')
+      if (error) {
+        console.error('Error fetching data:', error)
+      } else {
+        console.log('Supabase query result:', data)
+      }
+    } catch (err) {
+      console.error('Unexpected error:', err)
+    }
+  })
+}


### PR DESCRIPTION
## Summary
- setup Supabase client in its own module
- query `test_logs` on button click and log result or error

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689002039d7c8329b3a5c417376c3b8b