### PR TITLE
Add SQL script for test_logs table

### DIFF
--- a/create_test_logs.sql
+++ b/create_test_logs.sql
@@ -1,0 +1,5 @@
+CREATE TABLE IF NOT EXISTS test_logs (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  message text,
+  created_at timestamp DEFAULT now()
+);


### PR DESCRIPTION
## Summary
- add SQL script to create a `test_logs` table for connection tests

## Testing
- `curl -i -X POST 'https://gxewpstvuoofdqanhjzi.supabase.co/rest/v1/rpc'   -H "Content-Type: application/json"   -H "apikey: sb_publishable_BDdV5w6oEVsrnwBL5f-zhw_Xdjkm7ip"   -H "Authorization: Bearer sb_publishable_BDdV5w6oEVsrnwBL5f-zhw_Xdjkm7ip"   -d '{"query":"CREATE TABLE IF NOT EXISTS test_logs (id uuid PRIMARY KEY DEFAULT gen_random_uuid(), message text, created_at timestamp DEFAULT now());"}'` *(403: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_689006340e248329b0435ec0200a0403