### PR TITLE
Add Supabase test script

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "type": "module",
   "dependencies": {
     "@supabase/supabase-js": "^2.53.0"
   }

--- a/testSupabase.js
+++ b/testSupabase.js
@@ -1,17 +1,21 @@
-import { supabase } from './supabaseClient.js'
+import { createClient } from '@supabase/supabase-js'
 
-const button = document.querySelector('.test-supabase-button')
-if (button) {
-  button.addEventListener('click', async () => {
-    try {
-      const { data, error } = await supabase.from('test_logs').select('*')
-      if (error) {
-        console.error('Error fetching data:', error)
-      } else {
-        console.log('Supabase query result:', data)
-      }
-    } catch (err) {
-      console.error('Unexpected error:', err)
-    }
-  })
+const supabaseUrl = 'https://gxewpstvuoofdqanhjzi.supabase.co'
+const supabaseKey = 'sb_publishable_BDdV5w6oEVsrnwBL5f-zhw_Xdjkm7ip'
+const supabase = createClient(supabaseUrl, supabaseKey)
+
+async function testSupabase() {
+  const { data, error } = await supabase.from('test_logs').select('*')
+
+  if (error) {
+    console.error('Supabase error:', error)
+  } else {
+    console.log('Supabase query result:', data)
+    data.forEach((row) => {
+      console.log('Message:', row.message)
+    })
+  }
 }
+
+testSupabase()
+


### PR DESCRIPTION
## Summary
- add standalone script to query `test_logs` table via Supabase
- set package to ESM for module-based imports

## Testing
- `node testSupabase.js` *(fails: TypeError: fetch failed)*
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68900b87ee08832981c2fd10cd1f581f