### PR TITLE
Display Supabase messages on page

### DIFF
--- a/index.html
+++ b/index.html
@@ -76,6 +76,7 @@
   <p>A Magical World of Learning</p>
   <button class="coming-soon-button">Coming Soon</button>
   <button id="testButton" class="test-supabase-button">Test Supabase</button>
+  <div id="result" style="margin-top: 20px;"></div>
 
   <script type="module" src="index.js"></script>
 </body>

--- a/testSupabase.js
+++ b/testSupabase.js
@@ -2,14 +2,21 @@ import { supabase } from './supabaseClient.js'
 
 export async function testSupabase() {
   const { data, error } = await supabase.from('test_logs').select('*')
+  const resultDiv = document.getElementById('result')
 
   if (error) {
     console.error('Supabase error:', error)
+    if (resultDiv) {
+      resultDiv.innerText = `Error: ${error.message}`
+    }
   } else {
     console.log('Supabase query result:', data)
     data.forEach((row) => {
       console.log('Message:', row.message)
     })
+    if (resultDiv) {
+      resultDiv.innerText = data.map((row) => row.message).join('\n')
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- Add `<div id="result">` placeholder under "Test Supabase" button for showing query results
- Populate result div with messages returned from Supabase or an error message

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68900f8024708329b386d0158fcabb62