### PR TITLE
Integrate Supabase auth utilities and UI

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -1,0 +1,22 @@
+import { supabase } from './supabaseClient.js'
+
+export async function signUp(email, password) {
+  const { data, error } = await supabase.auth.signUp({
+    email,
+    password,
+  })
+  return { user: data.user, error }
+}
+
+export async function signIn(email, password) {
+  const { data, error } = await supabase.auth.signInWithPassword({
+    email,
+    password,
+  })
+  return { user: data.user, error }
+}
+
+export async function signOut() {
+  await supabase.auth.signOut()
+}
+

--- a/index.html
+++ b/index.html
@@ -76,6 +76,16 @@
   <p>A Magical World of Learning</p>
   <button class="coming-soon-button">Coming Soon</button>
   <button id="testButton" class="test-supabase-button">Test Supabase</button>
+
+  <div style="margin-top: 20px;">
+    <input type="email" id="email" placeholder="Email" />
+    <input type="password" id="password" placeholder="Password" />
+    <button id="signupButton">Sign Up</button>
+    <button id="loginButton">Log In</button>
+    <button id="logoutButton">Log Out</button>
+    <p id="authResult"></p>
+  </div>
+
   <div id="result" style="margin-top: 20px;"></div>
 
   <script type="module" src="index.js"></script>

--- a/index.js
+++ b/index.js
@@ -1,9 +1,29 @@
 import { testSupabase } from './testSupabase.js'
+import { signUp, signIn, signOut } from './auth.js'
 
 document.addEventListener('DOMContentLoaded', () => {
   const button = document.getElementById('testButton')
   if (button) {
     button.addEventListener('click', testSupabase)
+  }
+
+  const emailInput = document.getElementById('email')
+  const passwordInput = document.getElementById('password')
+  const resultText = document.getElementById('authResult')
+
+  document.getElementById('signupButton').onclick = async () => {
+    const { user, error } = await signUp(emailInput.value, passwordInput.value)
+    resultText.textContent = error ? error.message : `Signed up as ${user.email}`
+  }
+
+  document.getElementById('loginButton').onclick = async () => {
+    const { user, error } = await signIn(emailInput.value, passwordInput.value)
+    resultText.textContent = error ? error.message : `Logged in as ${user.email}`
+  }
+
+  document.getElementById('logoutButton').onclick = async () => {
+    await signOut()
+    resultText.textContent = 'Logged out'
   }
 })
 

--- a/supabaseClient.js
+++ b/supabaseClient.js
@@ -1,6 +1,6 @@
-import { createClient } from 'https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.53.0/+esm'
+import { createClient } from '@supabase/supabase-js'
 
 const supabaseUrl = 'https://gxewpstvuoofdqanhjzi.supabase.co'
-const supabaseAnonKey = 'sb_publishable_BDdV5w6oEVsrnwBL5f-zhw_Xdjkm7ip'
+const supabaseKey = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Imd4ZXdwc3R2dW9vZmRxYW5oanppIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTQwNjM1NzUsImV4cCI6MjA2OTYzOTU3NX0._W88NSjDmv4dXoE701SKMQ60J8D3DTCcRX5VVRJYr_E'
 
-export const supabase = createClient(supabaseUrl, supabaseAnonKey)
+export const supabase = createClient(supabaseUrl, supabaseKey)


### PR DESCRIPTION
## Summary
- replace Supabase client setup with project URL/key
- add auth helper module for sign-up/in/out
- extend landing page with auth form and hook up auth actions in main script

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68901192fd0883299b47d3d36f25c696