### PR TITLE
feat: save user profile after auth

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -1,0 +1,19 @@
+import { supabase } from './supabaseClient.js'
+import { saveUserProfile } from './profile.js'
+
+export async function signUpWithPassword({ email, password }) {
+  const { data, error } = await supabase.auth.signUp({ email, password })
+  if (data?.user) {
+    await saveUserProfile(data.user)
+  }
+  return { data, error }
+}
+
+export async function signInWithPassword({ email, password }) {
+  const { data, error } = await supabase.auth.signInWithPassword({ email, password })
+  if (data?.user) {
+    await saveUserProfile(data.user)
+  }
+  return { data, error }
+}
+

--- a/profile.js
+++ b/profile.js
@@ -1,0 +1,18 @@
+import { supabase } from './supabaseClient.js'
+
+export async function saveUserProfile(user) {
+  const username = user.email ? user.email.split('@')[0] : null
+  const avatar_url = user.user_metadata?.avatar_url || null
+
+  const { error } = await supabase.from('users').upsert({
+    id: user.id,
+    email: user.email,
+    username,
+    avatar_url
+  })
+
+  if (error) {
+    console.error('Error saving user profile:', error)
+  }
+}
+


### PR DESCRIPTION
## Summary
- add profile helper to upsert user data in Supabase
- ensure sign up/in flows save user profiles

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68905e02c9848329a9afd91b4e29f290