### PR TITLE
feat: save user profile on signup

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -1,11 +1,23 @@
 import { supabase } from './supabaseClient.js'
 
+async function saveProfile(user) {
+  const { error } = await supabase.from('profiles').upsert({
+    id: user.id,
+    email: user.email,
+  })
+  return error
+}
+
 export async function signUp(email, password) {
   const { data, error } = await supabase.auth.signUp({
     email,
     password,
   })
-  return { user: data.user, error }
+  let profileError = null
+  if (!error && data.user) {
+    profileError = await saveProfile(data.user)
+  }
+  return { user: data.user, error: error || profileError }
 }
 
 export async function signIn(email, password) {


### PR DESCRIPTION
## Summary
- ensure new users have profiles saved after sign-up

## Testing
- `npm test` (fails: Missing script: "test")
- `node -e "import('./auth.js')"`


------
https://chatgpt.com/codex/tasks/task_e_68905fca933c8329802c3dbf2ab8b234