### PR TITLE
Add user profile persistence and retrieval

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 import { testSupabase } from './testSupabase.js'
-import { signUp, signIn, signOut } from './auth.js'
+import { signUp, signIn, signOut, getUserProfile } from './auth.js'
 
 document.addEventListener('DOMContentLoaded', () => {
   const button = document.getElementById('testButton')
@@ -13,12 +13,26 @@ document.addEventListener('DOMContentLoaded', () => {
 
   document.getElementById('signupButton').onclick = async () => {
     const { user, error } = await signUp(emailInput.value, passwordInput.value)
-    resultText.textContent = error ? error.message : `Signed up as ${user.email}`
+    if (error) {
+      resultText.textContent = error.message
+      return
+    }
+    const profile = await getUserProfile()
+    resultText.textContent = profile
+      ? `Signed up as ${profile.email}`
+      : `Signed up as ${user.email}`
   }
 
   document.getElementById('loginButton').onclick = async () => {
     const { user, error } = await signIn(emailInput.value, passwordInput.value)
-    resultText.textContent = error ? error.message : `Logged in as ${user.email}`
+    if (error) {
+      resultText.textContent = error.message
+      return
+    }
+    const profile = await getUserProfile()
+    resultText.textContent = profile
+      ? `Logged in as ${profile.email}`
+      : `Logged in as ${user.email}`
   }
 
   document.getElementById('logoutButton').onclick = async () => {


### PR DESCRIPTION
## Summary
- ensure user profiles are stored or updated after sign-in or sign-up
- add utility to fetch the current user's profile and display it in the UI

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6890659b9c2c8329aa52d2ec81a00344