### PR TITLE
feat: add notifications feedback modules and dashboard

### DIFF
--- a/userFeatures.js
+++ b/userFeatures.js
@@ -101,3 +101,75 @@ export async function awardStamp(region, stamp_name) {
 
   return { data: data ? data[0] : null, error }
 }
+
+export async function sendNotification(userId, title, message, type = 'info') {
+  const { error } = await supabase
+    .from('notifications')
+    .insert({ user_id: userId, title, message, type, is_read: false })
+  return { error }
+}
+
+export async function markNotificationAsRead(notificationId) {
+  const { error } = await supabase
+    .from('notifications')
+    .update({ is_read: true })
+    .eq('id', notificationId)
+  return { error }
+}
+
+export async function submitFeedback(message, rating) {
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser()
+  if (authError || !user) {
+    return { error: authError || new Error('No authenticated user') }
+  }
+  const { error } = await supabase
+    .from('feedback')
+    .insert({ user_id: user.id, message, rating })
+  return { error }
+}
+
+export async function loadModulesByRegion(region) {
+  const { data, error } = await supabase
+    .from('learning_modules')
+    .select('*')
+    .eq('region', region)
+  const modules = data
+    ? data.map((m) => ({ ...m, hasQuiz: !!m.quiz_id }))
+    : []
+  return { data: modules, error }
+}
+
+export async function loadDashboard(userId) {
+  const [
+    { data: avatarData, error: avatarError },
+    { data: stampData, error: stampError },
+    { data: quizData, error: quizError },
+    { data: notificationData, error: notificationError },
+  ] = await Promise.all([
+    supabase.from('users').select('avatar_url').eq('id', userId).single(),
+    supabase.from('stamps').select('*').eq('user_id', userId),
+    supabase
+      .from('user_quiz_attempts')
+      .select('*')
+      .eq('user_id', userId)
+      .order('created_at', { ascending: false })
+      .limit(5),
+    supabase
+      .from('notifications')
+      .select('*')
+      .eq('user_id', userId)
+      .eq('is_read', false),
+  ])
+  return {
+    avatar: avatarData ? avatarData.avatar_url : null,
+    stamps: stampData || [],
+    quizAttempts: quizData || [],
+    notifications: notificationData || [],
+    errors: [avatarError, stampError, quizError, notificationError].filter(
+      Boolean
+    ),
+  }
+}


### PR DESCRIPTION
## Summary
- support sending and updating notifications
- allow users to submit feedback
- load learning modules and provide dashboard summary

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689069263a0083298ef6710b5a078e48