### PR TITLE
feat: add admin panel and search

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Admin Panel</title>
+</head>
+<body>
+  <h1>Admin Panel</h1>
+  <div id="modules"></div>
+  <div id="quizzes"></div>
+  <div id="feedback"></div>
+  <script type="module" src="admin.js"></script>
+</body>
+</html>

--- a/admin.js
+++ b/admin.js
@@ -1,0 +1,93 @@
+import { getUserProfile } from './auth.js'
+import { supabase } from './supabaseClient.js'
+import {
+  updateLearningModule,
+  deleteLearningModule,
+  updateQuiz,
+  deleteQuiz,
+} from './userFeatures.js'
+
+document.addEventListener('DOMContentLoaded', async () => {
+  const profile = await getUserProfile()
+  if (!profile || profile.role !== 'admin') {
+    window.location.href = '/'
+    return
+  }
+  loadModules()
+  loadQuizzes()
+  loadFeedback()
+})
+
+async function loadModules() {
+  const { data } = await supabase.from('learning_modules').select('*')
+  const container = document.getElementById('modules')
+  container.innerHTML = '<h2>Learning Modules</h2>'
+  ;(data || []).forEach((m) => {
+    const div = document.createElement('div')
+    div.textContent = m.title
+    const edit = document.createElement('button')
+    edit.textContent = 'Edit'
+    edit.onclick = async () => {
+      const title = prompt('New title', m.title)
+      if (title !== null) {
+        await updateLearningModule(m.id, { title })
+        loadModules()
+      }
+    }
+    const del = document.createElement('button')
+    del.textContent = 'Delete'
+    del.onclick = async () => {
+      if (confirm('Delete module?')) {
+        await deleteLearningModule(m.id)
+        loadModules()
+      }
+    }
+    div.appendChild(edit)
+    div.appendChild(del)
+    container.appendChild(div)
+  })
+}
+
+async function loadQuizzes() {
+  const { data } = await supabase.from('quizzes').select('*')
+  const container = document.getElementById('quizzes')
+  container.innerHTML = '<h2>Quizzes</h2>'
+  ;(data || []).forEach((q) => {
+    const div = document.createElement('div')
+    div.textContent = q.title
+    const edit = document.createElement('button')
+    edit.textContent = 'Edit'
+    edit.onclick = async () => {
+      const title = prompt('New title', q.title)
+      if (title !== null) {
+        await updateQuiz(q.id, { title })
+        loadQuizzes()
+      }
+    }
+    const del = document.createElement('button')
+    del.textContent = 'Delete'
+    del.onclick = async () => {
+      if (confirm('Delete quiz?')) {
+        await deleteQuiz(q.id)
+        loadQuizzes()
+      }
+    }
+    div.appendChild(edit)
+    div.appendChild(del)
+    container.appendChild(div)
+  })
+}
+
+async function loadFeedback() {
+  const { data } = await supabase
+    .from('feedback')
+    .select('*')
+    .order('created_at', { ascending: false })
+  const container = document.getElementById('feedback')
+  container.innerHTML = '<h2>Feedback Reports</h2>'
+  ;(data || []).forEach((f) => {
+    const div = document.createElement('div')
+    div.textContent = `${f.message} (rating: ${f.rating})`
+    container.appendChild(div)
+  })
+}

--- a/index.html
+++ b/index.html
@@ -78,6 +78,12 @@
   <button id="testButton" class="test-supabase-button">Test Supabase</button>
 
   <div style="margin-top: 20px;">
+    <input type="text" id="globalSearch" placeholder="Search modules or quizzes" />
+    <button id="searchButton">Search</button>
+  </div>
+  <div id="searchResults" style="margin-top: 10px;"></div>
+
+  <div style="margin-top: 20px;">
     <input type="email" id="email" placeholder="Email" />
     <input type="password" id="password" placeholder="Password" />
     <button id="signupButton">Sign Up</button>

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 import { testSupabase } from './testSupabase.js'
 import { signUp, signIn, signOut, getUserProfile } from './auth.js'
+import { searchContent } from './userFeatures.js'
 
 document.addEventListener('DOMContentLoaded', () => {
   const button = document.getElementById('testButton')
@@ -38,6 +39,23 @@ document.addEventListener('DOMContentLoaded', () => {
   document.getElementById('logoutButton').onclick = async () => {
     await signOut()
     resultText.textContent = 'Logged out'
+  }
+
+  const searchInput = document.getElementById('globalSearch')
+  const searchButton = document.getElementById('searchButton')
+  const searchResults = document.getElementById('searchResults')
+  if (searchButton && searchInput && searchResults) {
+    searchButton.addEventListener('click', async () => {
+      const term = searchInput.value
+      const { modules, quizzes, errors } = await searchContent(term)
+      if (errors.length) {
+        searchResults.textContent = errors[0].message
+        return
+      }
+      const modList = modules.map((m) => `Module: ${m.title}`).join('<br>')
+      const quizList = quizzes.map((q) => `Quiz: ${q.title}`).join('<br>')
+      searchResults.innerHTML = [modList, quizList].filter(Boolean).join('<br>')
+    })
   }
 })
 


### PR DESCRIPTION
## Summary
- add basic admin page with module, quiz, and feedback management
- support editing and deleting quizzes and modules
- add global search bar and log user activity to feed

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68906be13d108329afa852211a59f304