### PR TITLE
Add admin dashboards with route protection and data views

### DIFF
--- a/components/AdminNavbar.js
+++ b/components/AdminNavbar.js
@@ -1,0 +1,22 @@
+import Link from 'next/link'
+import { useRouter } from 'next/router'
+import { supabase } from '../supabaseClient.js'
+
+export default function AdminNavbar() {
+  const router = useRouter()
+
+  const handleLogout = async () => {
+    await supabase.auth.signOut()
+    router.push('/')
+  }
+
+  return (
+    <nav style={{ display: 'flex', gap: '1rem', padding: '1rem', borderBottom: '1px solid #ccc' }}>
+      <Link href="/admin-panel">Dashboard</Link>
+      <Link href="/admin-feedback">Feedback</Link>
+      <Link href="/admin-notifications">Notifications</Link>
+      <Link href="/admin-quiz-results">Quiz Results</Link>
+      <button onClick={handleLogout}>Logout</button>
+    </nav>
+  )
+}

--- a/lib/protectAdmin.js
+++ b/lib/protectAdmin.js
@@ -1,0 +1,11 @@
+import { supabase } from '../supabaseClient.js'
+
+export async function protectAdmin(router) {
+  const { data } = await supabase.auth.getSession()
+  const role = data.session?.user?.user_metadata?.role
+  if (role !== 'admin') {
+    router.push('/')
+    return false
+  }
+  return true
+}

--- a/pages/admin-feedback.js
+++ b/pages/admin-feedback.js
@@ -1,0 +1,54 @@
+import { useEffect, useState } from 'react'
+import { useRouter } from 'next/router'
+import { supabase } from '../supabaseClient.js'
+import AdminNavbar from '../components/AdminNavbar.js'
+import { protectAdmin } from '../lib/protectAdmin.js'
+
+export default function AdminFeedback() {
+  const router = useRouter()
+  const [loading, setLoading] = useState(true)
+  const [feedback, setFeedback] = useState([])
+
+  useEffect(() => {
+    async function load() {
+      const ok = await protectAdmin(router)
+      if (!ok) return
+      const { data } = await supabase
+        .from('feedback')
+        .select('*')
+        .order('created_at', { ascending: false })
+      setFeedback(data || [])
+      setLoading(false)
+    }
+    load()
+  }, [router])
+
+  if (loading) return <div>Loading...</div>
+
+  return (
+    <div>
+      <AdminNavbar />
+      <h1>Feedback</h1>
+      <table>
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Email</th>
+            <th>Message</th>
+            <th>Date</th>
+          </tr>
+        </thead>
+        <tbody>
+          {feedback.map((f) => (
+            <tr key={f.id}>
+              <td>{f.name}</td>
+              <td>{f.email}</td>
+              <td>{f.message}</td>
+              <td>{new Date(f.created_at).toLocaleString()}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/pages/admin-notifications.js
+++ b/pages/admin-notifications.js
@@ -1,0 +1,62 @@
+import { useEffect, useState } from 'react'
+import { useRouter } from 'next/router'
+import { supabase } from '../supabaseClient.js'
+import AdminNavbar from '../components/AdminNavbar.js'
+import { protectAdmin } from '../lib/protectAdmin.js'
+
+export default function AdminNotifications() {
+  const router = useRouter()
+  const [loading, setLoading] = useState(true)
+  const [notifications, setNotifications] = useState([])
+
+  useEffect(() => {
+    async function load() {
+      const ok = await protectAdmin(router)
+      if (!ok) return
+      const { data } = await supabase
+        .from('notifications')
+        .select('*')
+        .order('created_at', { ascending: false })
+      setNotifications(data || [])
+      setLoading(false)
+    }
+    load()
+  }, [router])
+
+  if (loading) return <div>Loading...</div>
+
+  return (
+    <div>
+      <AdminNavbar />
+      <h1>Notifications</h1>
+      <ul style={{ listStyle: 'none', padding: 0 }}>
+        {notifications.map((n) => (
+          <li
+            key={n.id}
+            style={{
+              backgroundColor: n.read ? 'white' : '#eef',
+              marginBottom: '1rem',
+              padding: '1rem',
+              border: '1px solid #ccc',
+            }}
+          >
+            <div style={{ fontWeight: 'bold' }}>{n.title}</div>
+            <div>{n.message}</div>
+            <span
+              style={{
+                display: 'inline-block',
+                margin: '0.5rem 0',
+                padding: '0.25rem 0.5rem',
+                border: '1px solid #ccc',
+                borderRadius: '4px',
+              }}
+            >
+              {n.type}
+            </span>
+            <div>{new Date(n.created_at).toLocaleString()}</div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/pages/admin-panel.js
+++ b/pages/admin-panel.js
@@ -1,0 +1,26 @@
+import { useRouter } from 'next/router'
+import { useEffect, useState } from 'react'
+import AdminNavbar from '../components/AdminNavbar.js'
+import { protectAdmin } from '../lib/protectAdmin.js'
+
+export default function AdminPanel() {
+  const router = useRouter()
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    async function check() {
+      const ok = await protectAdmin(router)
+      if (ok) setLoading(false)
+    }
+    check()
+  }, [router])
+
+  if (loading) return <div>Loading...</div>
+
+  return (
+    <div>
+      <AdminNavbar />
+      <h1>Admin Panel</h1>
+    </div>
+  )
+}

--- a/pages/admin-quiz-results.js
+++ b/pages/admin-quiz-results.js
@@ -1,0 +1,54 @@
+import { useEffect, useState } from 'react'
+import { useRouter } from 'next/router'
+import { supabase } from '../supabaseClient.js'
+import AdminNavbar from '../components/AdminNavbar.js'
+import { protectAdmin } from '../lib/protectAdmin.js'
+
+export default function AdminQuizResults() {
+  const router = useRouter()
+  const [loading, setLoading] = useState(true)
+  const [results, setResults] = useState([])
+
+  useEffect(() => {
+    async function load() {
+      const ok = await protectAdmin(router)
+      if (!ok) return
+      const { data } = await supabase
+        .from('user_quiz_attempts')
+        .select('score, completed_at, users ( username ), quizzes ( title )')
+        .order('completed_at', { ascending: false })
+      setResults(data || [])
+      setLoading(false)
+    }
+    load()
+  }, [router])
+
+  if (loading) return <div>Loading...</div>
+
+  return (
+    <div>
+      <AdminNavbar />
+      <h1>Quiz Results</h1>
+      <table>
+        <thead>
+          <tr>
+            <th>User</th>
+            <th>Quiz</th>
+            <th>Score</th>
+            <th>Completed At</th>
+          </tr>
+        </thead>
+        <tbody>
+          {results.map((r, idx) => (
+            <tr key={idx}>
+              <td>{r.users?.username}</td>
+              <td>{r.quizzes?.title}</td>
+              <td>{r.score}</td>
+              <td>{new Date(r.completed_at).toLocaleString()}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add reusable admin protection helper and navbar component
- build admin dashboard, feedback, notifications, and quiz results pages

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68906f375230832989900658ae2ae8d8