### PR TITLE
Add admin dashboard and sidebar navigation

### DIFF
--- a/components/AdminNavbar.js
+++ b/components/AdminNavbar.js
@@ -1,22 +1,80 @@
 import Link from 'next/link'
 import { useRouter } from 'next/router'
+import { useState } from 'react'
 import { supabase } from '../supabaseClient.js'
 
 export default function AdminNavbar() {
   const router = useRouter()
+  const [open, setOpen] = useState(false)
 
   const handleLogout = async () => {
     await supabase.auth.signOut()
+    if (typeof window !== 'undefined') {
+      try {
+        localStorage.clear()
+        sessionStorage.clear()
+      } catch (e) {
+        // ignore
+      }
+    }
     router.push('/')
   }
 
+  const links = [
+    { href: '/admin-dashboard', label: '🏠 Dashboard' },
+    { href: '/admin-feedback', label: '💬 Feedback' },
+    { href: '/admin-notifications', label: '🔔 Notifications' },
+    { href: '/admin-quiz-results', label: '📊 Quiz Results' },
+  ]
+
   return (
-    <nav style={{ display: 'flex', gap: '1rem', padding: '1rem', borderBottom: '1px solid #ccc' }}>
-      <Link href="/admin-panel">Dashboard</Link>
-      <Link href="/admin-feedback">Feedback</Link>
-      <Link href="/admin-notifications">Notifications</Link>
-      <Link href="/admin-quiz-results">Quiz Results</Link>
-      <button onClick={handleLogout}>Logout</button>
-    </nav>
+    <>
+      <button className="admin-hamburger" onClick={() => setOpen(!open)}>
+        ☰
+      </button>
+      <nav className={`admin-sidebar ${open ? 'open' : ''}`}>
+        {links.map((l) => (
+          <Link key={l.href} href={l.href} onClick={() => setOpen(false)}>
+            {l.label}
+          </Link>
+        ))}
+        <button onClick={handleLogout}>Logout</button>
+      </nav>
+      <style jsx>{`
+        .admin-hamburger {
+          display: none;
+          background: none;
+          border: none;
+          font-size: 1.5rem;
+          margin: 0.5rem;
+        }
+        .admin-sidebar {
+          display: flex;
+          flex-direction: column;
+          gap: 1rem;
+          padding: 1rem;
+          border-right: 1px solid #ccc;
+          min-width: 200px;
+          height: 100vh;
+        }
+        @media (max-width: 600px) {
+          .admin-hamburger {
+            display: block;
+          }
+          .admin-sidebar {
+            position: fixed;
+            left: -220px;
+            top: 0;
+            background: white;
+            width: 200px;
+            transition: left 0.3s;
+            z-index: 1000;
+          }
+          .admin-sidebar.open {
+            left: 0;
+          }
+        }
+      `}</style>
+    </>
   )
 }

--- a/pages/admin-dashboard.js
+++ b/pages/admin-dashboard.js
@@ -1,0 +1,77 @@
+import { useEffect, useState } from 'react'
+import { useRouter } from 'next/router'
+import AdminNavbar from '../components/AdminNavbar.js'
+import { supabase } from '../supabaseClient.js'
+import { protectAdmin } from '../lib/protectAdmin.js'
+
+export default function AdminDashboard() {
+  const router = useRouter()
+  const [loading, setLoading] = useState(true)
+  const [stats, setStats] = useState({ users: 0, quizzes: 0, feedback: 0, notifications: 0 })
+  const [username, setUsername] = useState('')
+
+  useEffect(() => {
+    async function load() {
+      const ok = await protectAdmin(router)
+      if (!ok) return
+      const { data: session } = await supabase.auth.getSession()
+      setUsername(
+        session.session?.user?.user_metadata?.username ||
+          session.session?.user?.email ||
+          'Admin'
+      )
+      const [u, q, f, n] = await Promise.all([
+        supabase.from('users').select('id', { count: 'exact', head: true }),
+        supabase.from('quizzes').select('id', { count: 'exact', head: true }),
+        supabase.from('feedback').select('id', { count: 'exact', head: true }),
+        supabase.from('notifications').select('id', { count: 'exact', head: true })
+      ])
+      setStats({
+        users: u.count || 0,
+        quizzes: q.count || 0,
+        feedback: f.count || 0,
+        notifications: n.count || 0
+      })
+      setLoading(false)
+    }
+    load()
+  }, [router])
+
+  if (loading) return <div>Loading...</div>
+
+  const cardStyle = {
+    border: '1px solid #ccc',
+    padding: '1rem',
+    borderRadius: '8px',
+    flex: '1',
+    minWidth: '150px',
+    textAlign: 'center'
+  }
+
+  return (
+    <div style={{ display: 'flex' }}>
+      <AdminNavbar />
+      <main style={{ flex: 1, padding: '1rem' }}>
+        <h1>Welcome, {username}</h1>
+        <div style={{ display: 'flex', gap: '1rem', flexWrap: 'wrap' }}>
+          <div style={cardStyle}>
+            <div>Total Users</div>
+            <div style={{ fontSize: '2rem' }}>{stats.users}</div>
+          </div>
+          <div style={cardStyle}>
+            <div>Total Quizzes</div>
+            <div style={{ fontSize: '2rem' }}>{stats.quizzes}</div>
+          </div>
+          <div style={cardStyle}>
+            <div>Total Feedback Messages</div>
+            <div style={{ fontSize: '2rem' }}>{stats.feedback}</div>
+          </div>
+          <div style={cardStyle}>
+            <div>Total Notifications Sent</div>
+            <div style={{ fontSize: '2rem' }}>{stats.notifications}</div>
+          </div>
+        </div>
+      </main>
+    </div>
+  )
+}

--- a/pages/admin-feedback.js
+++ b/pages/admin-feedback.js
@@ -26,29 +26,31 @@ export default function AdminFeedback() {
   if (loading) return <div>Loading...</div>
 
   return (
-    <div>
+    <div style={{ display: 'flex' }}>
       <AdminNavbar />
-      <h1>Feedback</h1>
-      <table>
-        <thead>
-          <tr>
-            <th>Name</th>
-            <th>Email</th>
-            <th>Message</th>
-            <th>Date</th>
-          </tr>
-        </thead>
-        <tbody>
-          {feedback.map((f) => (
-            <tr key={f.id}>
-              <td>{f.name}</td>
-              <td>{f.email}</td>
-              <td>{f.message}</td>
-              <td>{new Date(f.created_at).toLocaleString()}</td>
+      <main style={{ flex: 1, padding: '1rem' }}>
+        <h1>Feedback</h1>
+        <table>
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Email</th>
+              <th>Message</th>
+              <th>Date</th>
             </tr>
-          ))}
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+            {feedback.map((f) => (
+              <tr key={f.id}>
+                <td>{f.name}</td>
+                <td>{f.email}</td>
+                <td>{f.message}</td>
+                <td>{new Date(f.created_at).toLocaleString()}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </main>
     </div>
   )
 }

--- a/pages/admin-notifications.js
+++ b/pages/admin-notifications.js
@@ -26,37 +26,39 @@ export default function AdminNotifications() {
   if (loading) return <div>Loading...</div>
 
   return (
-    <div>
+    <div style={{ display: 'flex' }}>
       <AdminNavbar />
-      <h1>Notifications</h1>
-      <ul style={{ listStyle: 'none', padding: 0 }}>
-        {notifications.map((n) => (
-          <li
-            key={n.id}
-            style={{
-              backgroundColor: n.read ? 'white' : '#eef',
-              marginBottom: '1rem',
-              padding: '1rem',
-              border: '1px solid #ccc',
-            }}
-          >
-            <div style={{ fontWeight: 'bold' }}>{n.title}</div>
-            <div>{n.message}</div>
-            <span
+      <main style={{ flex: 1, padding: '1rem' }}>
+        <h1>Notifications</h1>
+        <ul style={{ listStyle: 'none', padding: 0 }}>
+          {notifications.map((n) => (
+            <li
+              key={n.id}
               style={{
-                display: 'inline-block',
-                margin: '0.5rem 0',
-                padding: '0.25rem 0.5rem',
+                backgroundColor: n.read ? 'white' : '#eef',
+                marginBottom: '1rem',
+                padding: '1rem',
                 border: '1px solid #ccc',
-                borderRadius: '4px',
               }}
             >
-              {n.type}
-            </span>
-            <div>{new Date(n.created_at).toLocaleString()}</div>
-          </li>
-        ))}
-      </ul>
+              <div style={{ fontWeight: 'bold' }}>{n.title}</div>
+              <div>{n.message}</div>
+              <span
+                style={{
+                  display: 'inline-block',
+                  margin: '0.5rem 0',
+                  padding: '0.25rem 0.5rem',
+                  border: '1px solid #ccc',
+                  borderRadius: '4px',
+                }}
+              >
+                {n.type}
+              </span>
+              <div>{new Date(n.created_at).toLocaleString()}</div>
+            </li>
+          ))}
+        </ul>
+      </main>
     </div>
   )
 }

--- a/pages/admin-panel.js
+++ b/pages/admin-panel.js
@@ -18,9 +18,11 @@ export default function AdminPanel() {
   if (loading) return <div>Loading...</div>
 
   return (
-    <div>
+    <div style={{ display: 'flex' }}>
       <AdminNavbar />
-      <h1>Admin Panel</h1>
+      <main style={{ flex: 1, padding: '1rem' }}>
+        <h1>Admin Panel</h1>
+      </main>
     </div>
   )
 }

--- a/pages/admin-quiz-results.js
+++ b/pages/admin-quiz-results.js
@@ -26,29 +26,31 @@ export default function AdminQuizResults() {
   if (loading) return <div>Loading...</div>
 
   return (
-    <div>
+    <div style={{ display: 'flex' }}>
       <AdminNavbar />
-      <h1>Quiz Results</h1>
-      <table>
-        <thead>
-          <tr>
-            <th>User</th>
-            <th>Quiz</th>
-            <th>Score</th>
-            <th>Completed At</th>
-          </tr>
-        </thead>
-        <tbody>
-          {results.map((r, idx) => (
-            <tr key={idx}>
-              <td>{r.users?.username}</td>
-              <td>{r.quizzes?.title}</td>
-              <td>{r.score}</td>
-              <td>{new Date(r.completed_at).toLocaleString()}</td>
+      <main style={{ flex: 1, padding: '1rem' }}>
+        <h1>Quiz Results</h1>
+        <table>
+          <thead>
+            <tr>
+              <th>User</th>
+              <th>Quiz</th>
+              <th>Score</th>
+              <th>Completed At</th>
             </tr>
-          ))}
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+            {results.map((r, idx) => (
+              <tr key={idx}>
+                <td>{r.users?.username}</td>
+                <td>{r.quizzes?.title}</td>
+                <td>{r.score}</td>
+                <td>{new Date(r.completed_at).toLocaleString()}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </main>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- Implement admin dashboard to show counts of users, quizzes, feedback, and notifications while greeting the signed-in admin.
- Replace top nav with responsive vertical sidebar including links to admin tools and logout action.
- Wrap all admin pages in flex layout using sidebar and ensure admin routes remain protected.

## Testing
- `npm test` *(fails: Missing script "test"*)


------
https://chatgpt.com/codex/tasks/task_e_689071300a188329b1e1b54421f2a43f