### PR TITLE
Add admin management pages and navigation

### DIFF
--- a/components/AdminNavbar.js
+++ b/components/AdminNavbar.js
@@ -25,6 +25,7 @@ export default function AdminNavbar() {
     { href: '/admin-feedback', label: '💬 Feedback' },
     { href: '/admin-notifications', label: '🔔 Notifications' },
     { href: '/admin-quiz-results', label: '📊 Quiz Results' },
+    { href: '/admin-quiz-editor', label: '✏️ Quiz Editor' },
   ]
 
   return (
@@ -34,7 +35,12 @@ export default function AdminNavbar() {
       </button>
       <nav className={`admin-sidebar ${open ? 'open' : ''}`}>
         {links.map((l) => (
-          <Link key={l.href} href={l.href} onClick={() => setOpen(false)}>
+          <Link
+            key={l.href}
+            href={l.href}
+            onClick={() => setOpen(false)}
+            className={router.pathname === l.href ? 'active' : ''}
+          >
             {l.label}
           </Link>
         ))}
@@ -56,6 +62,10 @@ export default function AdminNavbar() {
           border-right: 1px solid #ccc;
           min-width: 200px;
           height: 100vh;
+        }
+        .admin-sidebar .active {
+          font-weight: bold;
+          text-decoration: underline;
         }
         @media (max-width: 600px) {
           .admin-hamburger {

--- a/pages/admin-feedback.js
+++ b/pages/admin-feedback.js
@@ -8,6 +8,9 @@ export default function AdminFeedback() {
   const router = useRouter()
   const [loading, setLoading] = useState(true)
   const [feedback, setFeedback] = useState([])
+  const pageSize = 20
+  const [page, setPage] = useState(0)
+  const [hasMore, setHasMore] = useState(true)
 
   useEffect(() => {
     async function load() {
@@ -15,13 +18,32 @@ export default function AdminFeedback() {
       if (!ok) return
       const { data } = await supabase
         .from('feedback')
-        .select('*')
+        .select('id, user_id, email, subject, message, created_at, users(username)')
         .order('created_at', { ascending: false })
+        .range(0, pageSize - 1)
       setFeedback(data || [])
+      setHasMore((data || []).length === pageSize)
       setLoading(false)
     }
     load()
   }, [router])
+
+  const loadMore = async () => {
+    const from = (page + 1) * pageSize
+    const to = from + pageSize - 1
+    const { data } = await supabase
+      .from('feedback')
+      .select('id, user_id, email, subject, message, created_at, users(username)')
+      .order('created_at', { ascending: false })
+      .range(from, to)
+    if (data && data.length > 0) {
+      setFeedback((prev) => [...prev, ...data])
+      setPage((p) => p + 1)
+      setHasMore(data.length === pageSize)
+    } else {
+      setHasMore(false)
+    }
+  }
 
   if (loading) return <div>Loading...</div>
 
@@ -30,26 +52,33 @@ export default function AdminFeedback() {
       <AdminNavbar />
       <main style={{ flex: 1, padding: '1rem' }}>
         <h1>Feedback</h1>
-        <table>
-          <thead>
-            <tr>
-              <th>Name</th>
-              <th>Email</th>
-              <th>Message</th>
-              <th>Date</th>
-            </tr>
-          </thead>
-          <tbody>
-            {feedback.map((f) => (
-              <tr key={f.id}>
-                <td>{f.name}</td>
-                <td>{f.email}</td>
-                <td>{f.message}</td>
-                <td>{new Date(f.created_at).toLocaleString()}</td>
+        <div style={{ maxHeight: '60vh', overflowY: 'auto' }}>
+          <table>
+            <thead>
+              <tr>
+                <th>User / Email</th>
+                <th>Subject</th>
+                <th>Message</th>
+                <th>Date</th>
               </tr>
-            ))}
-          </tbody>
-        </table>
+            </thead>
+            <tbody>
+              {feedback.map((f) => (
+                <tr key={f.id}>
+                  <td>{f.users?.username || f.email || 'Unknown'}</td>
+                  <td>{f.subject}</td>
+                  <td>{f.message}</td>
+                  <td>{new Date(f.created_at).toLocaleString()}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+        {hasMore && (
+          <button onClick={loadMore} style={{ marginTop: '1rem' }}>
+            Load More
+          </button>
+        )}
       </main>
     </div>
   )

--- a/pages/admin-notifications.js
+++ b/pages/admin-notifications.js
@@ -8,20 +8,63 @@ export default function AdminNotifications() {
   const router = useRouter()
   const [loading, setLoading] = useState(true)
   const [notifications, setNotifications] = useState([])
+  const [users, setUsers] = useState([])
+  const [title, setTitle] = useState('')
+  const [message, setMessage] = useState('')
+  const [target, setTarget] = useState('all')
 
   useEffect(() => {
     async function load() {
       const ok = await protectAdmin(router)
       if (!ok) return
+      const [notifRes, userRes] = await Promise.all([
+        supabase
+          .from('notifications')
+          .select('*')
+          .order('created_at', { ascending: false }),
+        supabase.from('users').select('id, email')
+      ])
+      setNotifications(notifRes.data || [])
+      setUsers(userRes.data || [])
+      setLoading(false)
+    }
+    load()
+  }, [router])
+
+  const handleSubmit = async (e) => {
+    e.preventDefault()
+    const payloads = []
+    if (target === 'all') {
+      payloads.push(
+        ...users.map((u) => ({
+          user_id: u.id,
+          title,
+          message,
+          type: 'admin',
+          is_read: false,
+        }))
+      )
+    } else {
+      payloads.push({
+        user_id: target,
+        title,
+        message,
+        type: 'admin',
+        is_read: false,
+      })
+    }
+    if (payloads.length > 0) {
+      await supabase.from('notifications').insert(payloads)
       const { data } = await supabase
         .from('notifications')
         .select('*')
         .order('created_at', { ascending: false })
       setNotifications(data || [])
-      setLoading(false)
     }
-    load()
-  }, [router])
+    setTitle('')
+    setMessage('')
+    setTarget('all')
+  }
 
   if (loading) return <div>Loading...</div>
 
@@ -30,12 +73,43 @@ export default function AdminNotifications() {
       <AdminNavbar />
       <main style={{ flex: 1, padding: '1rem' }}>
         <h1>Notifications</h1>
+        <form onSubmit={handleSubmit} style={{ marginBottom: '2rem' }}>
+          <div>
+            <input
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder="Title"
+              required
+            />
+          </div>
+          <div>
+            <textarea
+              value={message}
+              onChange={(e) => setMessage(e.target.value)}
+              placeholder="Message"
+              required
+              rows={3}
+              style={{ width: '100%' }}
+            />
+          </div>
+          <div>
+            <select value={target} onChange={(e) => setTarget(e.target.value)}>
+              <option value="all">All Users</option>
+              {users.map((u) => (
+                <option key={u.id} value={u.id}>
+                  {u.email}
+                </option>
+              ))}
+            </select>
+          </div>
+          <button type="submit">Send</button>
+        </form>
         <ul style={{ listStyle: 'none', padding: 0 }}>
           {notifications.map((n) => (
             <li
               key={n.id}
               style={{
-                backgroundColor: n.read ? 'white' : '#eef',
+                backgroundColor: n.is_read ? 'white' : '#eef',
                 marginBottom: '1rem',
                 padding: '1rem',
                 border: '1px solid #ccc',

--- a/pages/admin-quiz-editor.js
+++ b/pages/admin-quiz-editor.js
@@ -1,0 +1,118 @@
+import { useEffect, useState } from 'react'
+import { useRouter } from 'next/router'
+import { supabase } from '../supabaseClient.js'
+import AdminNavbar from '../components/AdminNavbar.js'
+import { protectAdmin } from '../lib/protectAdmin.js'
+
+export default function AdminQuizEditor() {
+  const router = useRouter()
+  const [loading, setLoading] = useState(true)
+  const [quizzes, setQuizzes] = useState([])
+  const [selected, setSelected] = useState(null)
+  const [title, setTitle] = useState('')
+  const [json, setJson] = useState('')
+
+  useEffect(() => {
+    async function load() {
+      const ok = await protectAdmin(router)
+      if (!ok) return
+      const { data } = await supabase
+        .from('quizzes')
+        .select('id, title, questions_data')
+        .order('created_at', { ascending: true })
+      setQuizzes(data || [])
+      setLoading(false)
+    }
+    load()
+  }, [router])
+
+  const handleSelect = (quiz) => {
+    setSelected(quiz)
+    setTitle(quiz.title)
+    setJson(JSON.stringify(quiz.questions_data, null, 2))
+  }
+
+  const handleNew = () => {
+    setSelected(null)
+    setTitle('')
+    setJson('')
+  }
+
+  const handleSave = async () => {
+    let parsed
+    try {
+      parsed = json ? JSON.parse(json) : []
+    } catch (e) {
+      alert('Invalid JSON')
+      return
+    }
+    if (selected) {
+      const { error } = await supabase
+        .from('quizzes')
+        .update({ title, questions_data: parsed })
+        .eq('id', selected.id)
+      if (!error) {
+        setQuizzes((qs) =>
+          qs.map((q) => (q.id === selected.id ? { ...q, title, questions_data: parsed } : q))
+        )
+      }
+    } else {
+      const { data, error } = await supabase
+        .from('quizzes')
+        .insert({ title, questions_data: parsed })
+        .select()
+        .single()
+      if (!error) {
+        setQuizzes((qs) => [...qs, data])
+        setSelected(data)
+      }
+    }
+  }
+
+  if (loading) return <div>Loading...</div>
+
+  return (
+    <div style={{ display: 'flex' }}>
+      <AdminNavbar />
+      <main style={{ flex: 1, padding: '1rem' }}>
+        <h1>Quiz Editor</h1>
+        <div style={{ display: 'flex' }}>
+          <aside style={{ width: '200px', marginRight: '1rem' }}>
+            <button onClick={handleNew} style={{ marginBottom: '1rem' }}>
+              + New Quiz
+            </button>
+            <ul style={{ listStyle: 'none', padding: 0 }}>
+              {quizzes.map((q) => (
+                <li key={q.id}>
+                  <button onClick={() => handleSelect(q)}>{q.title}</button>
+                </li>
+              ))}
+            </ul>
+          </aside>
+          <section style={{ flex: 1 }}>
+            <div>
+              <input
+                value={title}
+                onChange={(e) => setTitle(e.target.value)}
+                placeholder="Title"
+                style={{ width: '100%', marginBottom: '1rem' }}
+              />
+            </div>
+            <div>
+              <textarea
+                value={json}
+                onChange={(e) => setJson(e.target.value)}
+                rows={20}
+                style={{ width: '100%' }}
+                placeholder="Questions JSON"
+              />
+            </div>
+            <button onClick={handleSave} style={{ marginTop: '1rem' }}>
+              Save
+            </button>
+          </section>
+        </div>
+      </main>
+    </div>
+  )
+}

--- a/pages/admin-quiz-results.js
+++ b/pages/admin-quiz-results.js
@@ -8,6 +8,8 @@ export default function AdminQuizResults() {
   const router = useRouter()
   const [loading, setLoading] = useState(true)
   const [results, setResults] = useState([])
+  const [sortField, setSortField] = useState(null)
+  const [sortAsc, setSortAsc] = useState(true)
 
   useEffect(() => {
     async function load() {
@@ -23,6 +25,30 @@ export default function AdminQuizResults() {
     load()
   }, [router])
 
+  const sorted = [...results]
+  if (sortField === 'user') {
+    sorted.sort((a, b) => {
+      const aVal = a.users?.username || ''
+      const bVal = b.users?.username || ''
+      return sortAsc ? aVal.localeCompare(bVal) : bVal.localeCompare(aVal)
+    })
+  } else if (sortField === 'quiz') {
+    sorted.sort((a, b) => {
+      const aVal = a.quizzes?.title || ''
+      const bVal = b.quizzes?.title || ''
+      return sortAsc ? aVal.localeCompare(bVal) : bVal.localeCompare(aVal)
+    })
+  }
+
+  const handleSort = (field) => {
+    if (sortField === field) {
+      setSortAsc(!sortAsc)
+    } else {
+      setSortField(field)
+      setSortAsc(true)
+    }
+  }
+
   if (loading) return <div>Loading...</div>
 
   return (
@@ -33,14 +59,18 @@ export default function AdminQuizResults() {
         <table>
           <thead>
             <tr>
-              <th>User</th>
-              <th>Quiz</th>
+              <th onClick={() => handleSort('user')} style={{ cursor: 'pointer' }}>
+                User {sortField === 'user' ? (sortAsc ? '▲' : '▼') : ''}
+              </th>
+              <th onClick={() => handleSort('quiz')} style={{ cursor: 'pointer' }}>
+                Quiz {sortField === 'quiz' ? (sortAsc ? '▲' : '▼') : ''}
+              </th>
               <th>Score</th>
               <th>Completed At</th>
             </tr>
           </thead>
           <tbody>
-            {results.map((r, idx) => (
+            {sorted.map((r, idx) => (
               <tr key={idx}>
                 <td>{r.users?.username}</td>
                 <td>{r.quizzes?.title}</td>


### PR DESCRIPTION
## Summary
- build admin feedback viewer with pagination
- add notification manager to send and list notifications
- enable sorting in quiz results and add quiz editor
- expand admin sidebar with links and active highlighting

## Testing
- `npm test` (fails: Missing script: "test")


------
https://chatgpt.com/codex/tasks/task_e_689072c70d948329880bc8424e2053d1