### PR TITLE
Add admin role protections and module management tools

### DIFF
--- a/admin.js
+++ b/admin.js
@@ -9,7 +9,7 @@ import {
 
 document.addEventListener('DOMContentLoaded', async () => {
   const profile = await getUserProfile()
-  if (!profile || profile.role !== 'admin') {
+  if (!profile || !profile.is_admin) {
     window.location.href = '/'
     return
   }

--- a/auth.js
+++ b/auth.js
@@ -1,8 +1,14 @@
 import { supabase } from './supabaseClient.js'
 
 export async function saveUserProfile(user) {
-  const { id, email } = user
-  const { error } = await supabase.from('users').upsert({ id, email })
+  const { id, email, user_metadata } = user
+  const { error } = await supabase
+    .from('users')
+    .upsert({
+      id,
+      email,
+      is_admin: user_metadata?.is_admin || false,
+    })
   if (error) {
     console.error('Error saving user profile:', error)
   } else {

--- a/components/AdminNavbar.js
+++ b/components/AdminNavbar.js
@@ -26,6 +26,8 @@ export default function AdminNavbar() {
     { href: '/admin-notifications', label: '🔔 Notifications' },
     { href: '/admin-quiz-results', label: '📊 Quiz Results' },
     { href: '/admin-quiz-editor', label: '✏️ Quiz Editor' },
+    { href: '/admin-regions', label: '🗺️ Regions' },
+    { href: '/admin-module-uploader', label: '⬆️ Module Uploader' },
   ]
 
   return (

--- a/lib/protectAdmin.js
+++ b/lib/protectAdmin.js
@@ -1,9 +1,19 @@
 import { supabase } from '../supabaseClient.js'
 
 export async function protectAdmin(router) {
-  const { data } = await supabase.auth.getSession()
-  const role = data.session?.user?.user_metadata?.role
-  if (role !== 'admin') {
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) {
+    router.push('/')
+    return false
+  }
+  const { data, error } = await supabase
+    .from('users')
+    .select('is_admin')
+    .eq('id', user.id)
+    .single()
+  if (error || !data?.is_admin) {
     router.push('/')
     return false
   }

--- a/pages/admin-module-uploader.js
+++ b/pages/admin-module-uploader.js
@@ -1,0 +1,143 @@
+import { useEffect, useState } from 'react'
+import { useRouter } from 'next/router'
+import { supabase } from '../supabaseClient.js'
+import AdminNavbar from '../components/AdminNavbar.js'
+import { protectAdmin } from '../lib/protectAdmin.js'
+import { createLearningModule } from '../userFeatures.js'
+
+export default function AdminModuleUploader() {
+  const router = useRouter()
+  const [loading, setLoading] = useState(true)
+  const [regions, setRegions] = useState([])
+  const [quizzes, setQuizzes] = useState([])
+  const [form, setForm] = useState({
+    title: '',
+    description: '',
+    region: '',
+    content_type: '',
+    age_group: '',
+    quiz_id: '',
+    files: [],
+  })
+
+  useEffect(() => {
+    async function load() {
+      const ok = await protectAdmin(router)
+      if (!ok) return
+      const [reg, quiz] = await Promise.all([
+        supabase.from('regions').select('id, name'),
+        supabase.from('quizzes').select('id, title'),
+      ])
+      setRegions(reg.data || [])
+      setQuizzes(quiz.data || [])
+      setLoading(false)
+    }
+    load()
+  }, [router])
+
+  const handleSubmit = async (e) => {
+    e.preventDefault()
+    const uploads = []
+    for (const file of form.files) {
+      const filePath = `${Date.now()}_${file.name}`
+      const { error: upError } = await supabase.storage.from('modules').upload(filePath, file)
+      if (!upError) {
+        const { data } = supabase.storage.from('modules').getPublicUrl(filePath)
+        uploads.push(data.publicUrl)
+      }
+    }
+    const module = {
+      title: form.title,
+      description: form.description,
+      region: form.region,
+      content_type: form.content_type,
+      age_group: form.age_group,
+      media_urls: uploads,
+      quiz_id: form.quiz_id || null,
+    }
+    const { error } = await createLearningModule(module)
+    if (!error) {
+      alert('Module uploaded')
+      setForm({
+        title: '',
+        description: '',
+        region: '',
+        content_type: '',
+        age_group: '',
+        quiz_id: '',
+        files: [],
+      })
+    }
+  }
+
+  if (loading) return <div>Loading...</div>
+
+  return (
+    <div style={{ display: 'flex' }}>
+      <AdminNavbar />
+      <main style={{ flex: 1, padding: '1rem' }}>
+        <h1>Upload Learning Module</h1>
+        <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+          <input
+            value={form.title}
+            onChange={(e) => setForm({ ...form, title: e.target.value })}
+            placeholder="Title"
+            required
+          />
+          <textarea
+            value={form.description}
+            onChange={(e) => setForm({ ...form, description: e.target.value })}
+            placeholder="Description"
+            required
+          />
+          <select
+            value={form.region}
+            onChange={(e) => setForm({ ...form, region: e.target.value })}
+            required
+          >
+            <option value="">Select Region</option>
+            {regions.map((r) => (
+              <option key={r.id} value={r.name}>
+                {r.name}
+              </option>
+            ))}
+          </select>
+          <select
+            value={form.content_type}
+            onChange={(e) => setForm({ ...form, content_type: e.target.value })}
+            required
+          >
+            <option value="">Content Type</option>
+            <option value="storybook">Storybook</option>
+            <option value="video">Video</option>
+            <option value="game">Game</option>
+            <option value="other">Other</option>
+          </select>
+          <input
+            value={form.age_group}
+            onChange={(e) => setForm({ ...form, age_group: e.target.value })}
+            placeholder="Age group"
+          />
+          <select
+            value={form.quiz_id}
+            onChange={(e) => setForm({ ...form, quiz_id: e.target.value })}
+          >
+            <option value="">Related Quiz (optional)</option>
+            {quizzes.map((q) => (
+              <option key={q.id} value={q.id}>
+                {q.title}
+              </option>
+            ))}
+          </select>
+          <input
+            type="file"
+            multiple
+            onChange={(e) => setForm({ ...form, files: e.target.files })}
+          />
+          <button type="submit">Upload</button>
+        </form>
+      </main>
+    </div>
+  )
+}
+

--- a/pages/admin-regions.js
+++ b/pages/admin-regions.js
@@ -1,0 +1,132 @@
+import { useEffect, useState } from 'react'
+import { useRouter } from 'next/router'
+import { supabase } from '../supabaseClient.js'
+import AdminNavbar from '../components/AdminNavbar.js'
+import { protectAdmin } from '../lib/protectAdmin.js'
+
+export default function AdminRegions() {
+  const router = useRouter()
+  const [loading, setLoading] = useState(true)
+  const [usedRegions, setUsedRegions] = useState([])
+  const [regions, setRegions] = useState([])
+  const [newRegion, setNewRegion] = useState({ name: '', color: '', icon_url: '' })
+
+  useEffect(() => {
+    async function load() {
+      const ok = await protectAdmin(router)
+      if (!ok) return
+      await fetchData()
+      setLoading(false)
+    }
+    load()
+  }, [router])
+
+  async function fetchData() {
+    const [mods, quizzes, stamps, regionTable] = await Promise.all([
+      supabase.from('learning_modules').select('region'),
+      supabase.from('quizzes').select('region'),
+      supabase.from('stamps').select('region'),
+      supabase.from('regions').select('*').order('created_at'),
+    ])
+    const names = new Set()
+    ;[mods.data, quizzes.data, stamps.data].forEach((list) => {
+      ;(list || []).forEach((r) => r.region && names.add(r.region))
+    })
+    setUsedRegions([...names])
+    setRegions(regionTable.data || [])
+  }
+
+  const handleRegionChange = (id, field, value) => {
+    setRegions((prev) => prev.map((r) => (r.id === id ? { ...r, [field]: value } : r)))
+  }
+
+  const saveRegion = async (id) => {
+    const region = regions.find((r) => r.id === id)
+    const { data, error } = await supabase
+      .from('regions')
+      .update({ color: region.color, icon_url: region.icon_url })
+      .eq('id', id)
+      .select()
+      .single()
+    if (!error) {
+      setRegions((prev) => prev.map((r) => (r.id === id ? data : r)))
+    }
+  }
+
+  const addRegion = async (e) => {
+    e.preventDefault()
+    const { data, error } = await supabase
+      .from('regions')
+      .insert(newRegion)
+      .select()
+      .single()
+    if (!error && data) {
+      setRegions((prev) => [...prev, data])
+      setNewRegion({ name: '', color: '', icon_url: '' })
+    }
+  }
+
+  if (loading) return <div>Loading...</div>
+
+  return (
+    <div style={{ display: 'flex' }}>
+      <AdminNavbar />
+      <main style={{ flex: 1, padding: '1rem' }}>
+        <h1>Regions</h1>
+        <section>
+          <h2>Used Regions</h2>
+          <ul>
+            {usedRegions.map((r) => (
+              <li key={r}>{r}</li>
+            ))}
+          </ul>
+        </section>
+        <section>
+          <h2>Manage Regions</h2>
+          <form onSubmit={addRegion} style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}>
+            <input
+              value={newRegion.name}
+              onChange={(e) => setNewRegion({ ...newRegion, name: e.target.value })}
+              placeholder="Name"
+              required
+            />
+            <input
+              value={newRegion.color}
+              onChange={(e) => setNewRegion({ ...newRegion, color: e.target.value })}
+              placeholder="Color"
+            />
+            <input
+              value={newRegion.icon_url}
+              onChange={(e) => setNewRegion({ ...newRegion, icon_url: e.target.value })}
+              placeholder="Icon URL"
+            />
+            <button type="submit">Add</button>
+          </form>
+          <div style={{ marginTop: '1rem' }}>
+            {regions.map((r) => (
+              <div key={r.id} style={{ marginBottom: '0.5rem' }}>
+                <strong>{r.name}</strong>
+                <input
+                  value={r.color || ''}
+                  onChange={(e) => handleRegionChange(r.id, 'color', e.target.value)}
+                  placeholder="Color"
+                  style={{ marginLeft: '0.5rem' }}
+                />
+                <input
+                  value={r.icon_url || ''}
+                  onChange={(e) => handleRegionChange(r.id, 'icon_url', e.target.value)}
+                  placeholder="Icon URL"
+                  style={{ marginLeft: '0.5rem' }}
+                />
+                <button onClick={() => saveRegion(r.id)} style={{ marginLeft: '0.5rem' }}>
+                  Save
+                </button>
+              </div>
+            ))}
+          </div>
+        </section>
+      </main>
+    </div>
+  )
+}
+

--- a/pages/modules.js
+++ b/pages/modules.js
@@ -1,0 +1,54 @@
+import { useEffect, useState } from 'react'
+import { supabase } from '../supabaseClient.js'
+
+export default function ModulesPage() {
+  const [loading, setLoading] = useState(true)
+  const [grouped, setGrouped] = useState({})
+
+  useEffect(() => {
+    async function load() {
+      const { data } = await supabase.from('learning_modules').select('*')
+      const groups = {}
+      ;(data || []).forEach((m) => {
+        if (!groups[m.region]) groups[m.region] = []
+        groups[m.region].push(m)
+      })
+      setGrouped(groups)
+      setLoading(false)
+    }
+    load()
+  }, [])
+
+  if (loading) return <div>Loading...</div>
+
+  return (
+    <div style={{ padding: '1rem' }}>
+      {Object.entries(grouped).map(([region, mods]) => (
+        <section key={region} style={{ marginBottom: '2rem' }}>
+          <h2>{region}</h2>
+          <div style={{ display: 'flex', gap: '1rem', flexWrap: 'wrap' }}>
+            {mods.map((m) => (
+              <div key={m.id} style={{ border: '1px solid #ccc', padding: '0.5rem', width: '200px' }}>
+                {m.media_urls && m.media_urls[0] && (
+                  <img
+                    src={m.media_urls[0]}
+                    alt={m.title}
+                    style={{ width: '100%', height: 'auto' }}
+                  />
+                )}
+                <h3>{m.title}</h3>
+                <p>{m.description}</p>
+                {m.media_urls && m.media_urls[0] && (
+                  <a href={m.media_urls[0]} target="_blank" rel="noopener noreferrer">
+                    View
+                  </a>
+                )}
+              </div>
+            ))}
+          </div>
+        </section>
+      ))}
+    </div>
+  )
+}
+

--- a/userFeatures.js
+++ b/userFeatures.js
@@ -115,10 +115,10 @@ export async function createLearningModule(module) {
 
   const { data: profile, error: profileError } = await supabase
     .from('users')
-    .select('role')
+    .select('is_admin')
     .eq('id', user.id)
     .single()
-  if (profileError || profile.role !== 'admin') {
+  if (profileError || !profile.is_admin) {
     return { error: profileError || new Error('Unauthorized') }
   }
 


### PR DESCRIPTION
## Summary
- Enforce admin-only access using new `is_admin` checks and navigation links
- Add admin region management panel and module uploader with Supabase storage
- Provide public modules page showing learning modules grouped by region

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689074c111948329989d6996797b9418