### PR TITLE
Add region filter and quiz results pages with profile enhancements

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,0 +1,61 @@
+import { useEffect, useState } from 'react'
+import { supabase } from '../supabaseClient.js'
+
+export default function MyApp({ Component, pageProps }) {
+  const [avatarUrl, setAvatarUrl] = useState(null)
+
+  useEffect(() => {
+    async function load() {
+      const {
+        data: { user },
+      } = await supabase.auth.getUser()
+      if (!user) return
+      const { data } = await supabase
+        .from('users')
+        .select('avatar_url')
+        .eq('id', user.id)
+        .single()
+      setAvatarUrl(data?.avatar_url || null)
+    }
+    load()
+  }, [])
+
+  return (
+    <>
+      <nav
+        style={{
+          display: 'flex',
+          justifyContent: 'flex-end',
+          padding: '0.5rem 1rem',
+          borderBottom: '1px solid #ccc',
+        }}
+      >
+        <a
+          href="/profile"
+          style={{
+            width: 40,
+            height: 40,
+            borderRadius: '50%',
+            overflow: 'hidden',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            background: '#eee',
+          }}
+        >
+          {avatarUrl ? (
+            <img
+              src={avatarUrl}
+              alt="avatar"
+              style={{ width: '100%', height: '100%', objectFit: 'cover' }}
+            />
+          ) : (
+            <span style={{ fontSize: '1.5rem' }}>👤</span>
+          )}
+        </a>
+      </nav>
+      <Component {...pageProps} />
+    </>
+  )
+}
+

--- a/pages/admin/badges.js
+++ b/pages/admin/badges.js
@@ -1,0 +1,71 @@
+import { useEffect, useState } from 'react'
+import { supabase } from '../../supabaseClient.js'
+
+const regions = ['Thailandia', 'Chinadia', 'Bharatia', 'Australis', 'Americana']
+
+export default function AdminBadges() {
+  const [allowed, setAllowed] = useState(false)
+  const [users, setUsers] = useState([])
+  const [userId, setUserId] = useState('')
+  const [region, setRegion] = useState(regions[0])
+  const [status, setStatus] = useState('')
+
+  useEffect(() => {
+    async function load() {
+      const {
+        data: { user },
+      } = await supabase.auth.getUser()
+      if (!user || user.email !== 'turianmediacompany@gmail.com') {
+        setStatus('Access denied')
+        return
+      }
+      setAllowed(true)
+      const { data } = await supabase
+        .from('users')
+        .select('id, username, email')
+        .order('email')
+      setUsers(data || [])
+    }
+    load()
+  }, [])
+
+  const grant = async () => {
+    if (!userId) return
+    const { error } = await supabase.from('stamps').insert({
+      user_id: userId,
+      region,
+      stamp_name: `${region} Badge`,
+    })
+    setStatus(error ? 'Error granting stamp' : 'Stamp granted!')
+  }
+
+  if (!allowed) return <div>{status}</div>
+
+  return (
+    <div style={{ padding: '1rem' }}>
+      <h1>Grant Badge</h1>
+      <div style={{ marginBottom: '1rem' }}>
+        <select value={userId} onChange={(e) => setUserId(e.target.value)}>
+          <option value="">Select user</option>
+          {users.map((u) => (
+            <option key={u.id} value={u.id}>
+              {u.email || u.username}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div style={{ marginBottom: '1rem' }}>
+        <select value={region} onChange={(e) => setRegion(e.target.value)}>
+          {regions.map((r) => (
+            <option key={r} value={r}>
+              {r}
+            </option>
+          ))}
+        </select>
+      </div>
+      <button onClick={grant}>Grant Stamp</button>
+      {status && <p>{status}</p>}
+    </div>
+  )
+}
+

--- a/pages/profile.js
+++ b/pages/profile.js
@@ -1,0 +1,84 @@
+import { useEffect, useState } from 'react'
+import { supabase } from '../supabaseClient.js'
+import { uploadAvatar } from '../userFeatures.js'
+
+export default function ProfilePage() {
+  const [profile, setProfile] = useState(null)
+  const [stats, setStats] = useState({ quizzes: 0, stamps: 0 })
+  const [avatarUrl, setAvatarUrl] = useState(null)
+  const [uploading, setUploading] = useState(false)
+
+  useEffect(() => {
+    async function load() {
+      const {
+        data: { user },
+      } = await supabase.auth.getUser()
+      if (!user) return
+      const [{ data: userData }, { data: quizData }, { data: stampData }] = await Promise.all([
+        supabase
+          .from('users')
+          .select('username, email, avatar_url')
+          .eq('id', user.id)
+          .single(),
+        supabase.from('user_quiz_attempts').select('id').eq('user_id', user.id),
+        supabase.from('stamps').select('id').eq('user_id', user.id),
+      ])
+      setProfile(userData)
+      setAvatarUrl(userData?.avatar_url || null)
+      setStats({ quizzes: quizData?.length || 0, stamps: stampData?.length || 0 })
+    }
+    load()
+  }, [])
+
+  const handleAvatar = async (e) => {
+    const file = e.target.files[0]
+    if (!file) return
+    setUploading(true)
+    const { publicUrl, error } = await uploadAvatar(file)
+    if (!error) setAvatarUrl(publicUrl)
+    setUploading(false)
+  }
+
+  if (!profile) return <div>Loading...</div>
+
+  return (
+    <div style={{ padding: '1rem' }}>
+      <h1>Profile</h1>
+      <div style={{ marginBottom: '1rem' }}>
+        {avatarUrl ? (
+          <img
+            src={avatarUrl}
+            alt="avatar"
+            width={100}
+            height={100}
+            style={{ borderRadius: '50%' }}
+          />
+        ) : (
+          <div
+            style={{
+              width: 100,
+              height: 100,
+              borderRadius: '50%',
+              background: '#eee',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              fontSize: '3rem',
+            }}
+          >
+            👤
+          </div>
+        )}
+      </div>
+      <p>Username: {profile.username}</p>
+      <p>Email: {profile.email}</p>
+      <p>Total quizzes completed: {stats.quizzes}</p>
+      <p>Total stamps earned: {stats.stamps}</p>
+      <div style={{ margin: '1rem 0' }}>
+        <input type="file" onChange={handleAvatar} disabled={uploading} />
+      </div>
+      <button disabled>Edit Profile</button>
+    </div>
+  )
+}
+

--- a/pages/quiz-results/[attemptId].js
+++ b/pages/quiz-results/[attemptId].js
@@ -1,0 +1,54 @@
+import { useRouter } from 'next/router'
+import { useEffect, useState } from 'react'
+import { supabase } from '../../supabaseClient.js'
+
+export default function QuizResultsPage() {
+  const router = useRouter()
+  const { attemptId } = router.query
+  const [attempt, setAttempt] = useState(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    if (!attemptId) return
+    async function load() {
+      const { data } = await supabase
+        .from('user_quiz_attempts')
+        .select('*, quizzes ( title )')
+        .eq('id', attemptId)
+        .single()
+      setAttempt(data)
+      setLoading(false)
+    }
+    load()
+  }, [attemptId])
+
+  if (loading) return <div>Loading...</div>
+  if (!attempt) return <div>Attempt not found</div>
+
+  const responses = attempt.responses || []
+  const percentage = responses.length
+    ? Math.round((attempt.score / responses.length) * 100)
+    : 0
+
+  return (
+    <div style={{ padding: '1rem' }}>
+      <h1>{attempt.quizzes?.title || 'Quiz Results'}</h1>
+      <p>Score: {attempt.score}</p>
+      <p>{percentage >= 70 ? 'Great job!' : 'Try again!'}</p>
+      <ul>
+        {responses.map((r, idx) => (
+          <li key={idx} style={{ marginBottom: '1rem' }}>
+            <div>Question: {r.question}</div>
+            <div>Your answer: {r.answer}</div>
+            <div>Correct answer: {r.correct_answer}</div>
+            <div>{r.correct ? 'Correct' : 'Incorrect'}</div>
+          </li>
+        ))}
+      </ul>
+      {percentage < 70 && (
+        <a href={`/quiz/${attempt.quiz_id}`}>Retry Quiz</a>
+      )}
+    </div>
+  )
+}
+

--- a/pages/region/[region].js
+++ b/pages/region/[region].js
@@ -1,0 +1,82 @@
+import { useRouter } from 'next/router'
+import { useEffect, useState } from 'react'
+import { supabase } from '../../supabaseClient.js'
+
+export default function RegionPage() {
+  const router = useRouter()
+  const { region } = router.query
+  const [modules, setModules] = useState([])
+  const [stamps, setStamps] = useState([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    if (!region) return
+    async function load() {
+      const { data: modData } = await supabase
+        .from('learning_modules')
+        .select('*')
+        .eq('region', region)
+      const {
+        data: { user },
+      } = await supabase.auth.getUser()
+      let stampData = []
+      if (user) {
+        const { data } = await supabase
+          .from('stamps')
+          .select('*')
+          .eq('user_id', user.id)
+          .eq('region', region)
+        stampData = data || []
+      }
+      setModules(modData || [])
+      setStamps(stampData)
+      setLoading(false)
+    }
+    load()
+  }, [region])
+
+  if (loading) return <div>Loading...</div>
+
+  const completed = stamps.length
+  const total = modules.length
+
+  return (
+    <div style={{ padding: '1rem' }}>
+      <a href="/map">Back to Map</a>
+      <h1>{region}</h1>
+      <p>
+        {completed} out of {total} modules completed
+      </p>
+      <section style={{ marginTop: '1rem' }}>
+        <h2>Modules</h2>
+        <div style={{ display: 'flex', gap: '1rem', flexWrap: 'wrap' }}>
+          {modules.map((m) => (
+            <div
+              key={m.id}
+              style={{ border: '1px solid #ccc', padding: '0.5rem', width: '200px' }}
+            >
+              {m.media_urls && m.media_urls[0] && (
+                <img
+                  src={m.media_urls[0]}
+                  alt={m.title}
+                  style={{ width: '100%', height: 'auto' }}
+                />
+              )}
+              <h3>{m.title}</h3>
+            </div>
+          ))}
+        </div>
+      </section>
+      <section style={{ marginTop: '2rem' }}>
+        <h2>Stamps Earned</h2>
+        {stamps.length === 0 && <div>No stamps yet</div>}
+        <ul>
+          {stamps.map((s) => (
+            <li key={s.id}>{s.stamp_name}</li>
+          ))}
+        </ul>
+      </section>
+    </div>
+  )
+}
+


### PR DESCRIPTION
## Summary
- add region filter page with module progress and stamps
- add quiz results review page with retry link
- add admin badge grant tool and avatar navbar with profile page

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_689078d36e8c832996427d49883c800c