### PR TITLE
Add learning page, progress tracker, footer, and route protection

### DIFF
--- a/components/Footer.js
+++ b/components/Footer.js
@@ -1,0 +1,26 @@
+import React from 'react'
+
+export default function Footer() {
+  return (
+    <footer
+      style={{
+        marginTop: '2rem',
+        padding: '1rem',
+        textAlign: 'center',
+        background: '#f8f8f8',
+      }}
+    >
+      <div style={{ marginBottom: '0.5rem', display: 'flex', justifyContent: 'center', gap: '1rem', flexWrap: 'wrap' }}>
+        <a href="/">Home</a>
+        <a href="/map">Map</a>
+        <a href="/profile">Profile</a>
+        <a href="/learning-with-turian">Learn</a>
+      </div>
+      <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', gap: '0.5rem' }}>
+        <img src="/logo.png" alt="Turian logo" style={{ height: '24px' }} />
+        <span style={{ fontSize: '0.875rem' }}>© Turian Media</span>
+      </div>
+    </footer>
+  )
+}
+

--- a/components/ProgressBar.js
+++ b/components/ProgressBar.js
@@ -1,0 +1,36 @@
+import React from 'react'
+
+export default function ProgressBar({ totalModules = 0, completedModules = 0 }) {
+  const percentage = totalModules ? Math.min(100, (completedModules / totalModules) * 100) : 0
+  const fruitCount = Math.min(completedModules, 10)
+  return (
+    <div style={{ margin: '1rem 0' }}>
+      <div style={{ marginBottom: '0.25rem' }}>
+        {completedModules} of {totalModules} completed
+      </div>
+      <div
+        style={{
+          background: '#eee',
+          borderRadius: '8px',
+          overflow: 'hidden',
+          height: '20px',
+        }}
+      >
+        <div
+          style={{
+            width: `${percentage}%`,
+            background: '#8BC34A',
+            height: '100%',
+            transition: 'width 0.3s ease',
+          }}
+        />
+      </div>
+      <div style={{ marginTop: '0.25rem', fontSize: '1.25rem' }}>
+        {Array.from({ length: fruitCount }).map((_, i) => (
+          <span key={i}>🍓</span>
+        ))}
+      </div>
+    </div>
+  )
+}
+

--- a/pages/404.js
+++ b/pages/404.js
@@ -1,0 +1,17 @@
+export default function Custom404() {
+  return (
+    <div style={{ textAlign: 'center', padding: '2rem' }}>
+      <h1>404</h1>
+      <img
+        src="/logo.png"
+        alt="Turian looking lost"
+        style={{ width: 200, height: 200, opacity: 0.7 }}
+      />
+      <p>Oops! This page got squashed like a fruit.</p>
+      <a href="/">
+        <button style={{ padding: '0.5rem 1rem', borderRadius: '8px' }}>Back to Home</button>
+      </a>
+    </div>
+  )
+}
+

--- a/pages/learning-with-turian.js
+++ b/pages/learning-with-turian.js
@@ -1,0 +1,57 @@
+export default function LearningWithTurian() {
+  return (
+    <div
+      style={{
+        textAlign: 'center',
+        padding: '2rem',
+        background: 'linear-gradient(135deg, #ffecd2 0%, #fcb69f 100%)',
+        minHeight: '100vh',
+      }}
+    >
+      <h1 style={{ color: '#ff5722' }}>Learning with Turian</h1>
+      <img
+        src="/logo.png"
+        alt="Turian mascot"
+        style={{ width: 200, height: 200, animation: 'bounce 2s infinite' }}
+      />
+      <p style={{ margin: '1rem 0', fontSize: '1.2rem' }}>
+        Explore fun quizzes, earn kingdom stamps, and meet magical fruit and animal friends!
+      </p>
+      <div style={{ display: 'flex', justifyContent: 'center', gap: '1rem', flexWrap: 'wrap' }}>
+        <a href="/map">
+          <button
+            style={{
+              padding: '0.75rem 1.5rem',
+              background: '#4caf50',
+              color: 'white',
+              border: 'none',
+              borderRadius: '8px',
+            }}
+          >
+            Start Learning
+          </button>
+        </a>
+        <a href="/avatar">
+          <button
+            style={{
+              padding: '0.75rem 1.5rem',
+              background: '#2196f3',
+              color: 'white',
+              border: 'none',
+              borderRadius: '8px',
+            }}
+          >
+            Create Your Navatar
+          </button>
+        </a>
+      </div>
+      <style jsx>{`
+        @keyframes bounce {
+          0%, 100% { transform: translateY(0); }
+          50% { transform: translateY(-10px); }
+        }
+      `}</style>
+    </div>
+  )
+}
+

--- a/pages/map.js
+++ b/pages/map.js
@@ -1,11 +1,51 @@
+import { useEffect, useState } from 'react'
+import { supabase } from '../supabaseClient.js'
+import ProgressBar from '../components/ProgressBar.js'
+
 const regions = ['Thailandia', 'Chinadia', 'Bharatia', 'Australis', 'Americana']
 
 export default function MapPage() {
+  const [progress, setProgress] = useState({ total: 0, completed: 0 })
+
+  useEffect(() => {
+    async function load() {
+      const { data: modules } = await supabase.from('learning_modules').select('id')
+      const {
+        data: { user },
+      } = await supabase.auth.getUser()
+      let stamps = []
+      if (user) {
+        const { data } = await supabase
+          .from('stamps')
+          .select('id')
+          .eq('user_id', user.id)
+        stamps = data || []
+      }
+      setProgress({ total: modules?.length || 0, completed: stamps.length })
+    }
+    load()
+  }, [])
+
   return (
     <div style={{ padding: '1rem' }}>
       <h1>Kingdom Map</h1>
-      <img src="/logo.png" alt="Naturverse map" style={{ maxWidth: '100%', height: 'auto' }} />
-      <div style={{ marginTop: '1rem', display: 'flex', gap: '1rem', flexWrap: 'wrap' }}>
+      <ProgressBar
+        totalModules={progress.total}
+        completedModules={progress.completed}
+      />
+      <img
+        src="/logo.png"
+        alt="Naturverse map"
+        style={{ maxWidth: '100%', height: 'auto' }}
+      />
+      <div
+        style={{
+          marginTop: '1rem',
+          display: 'flex',
+          gap: '1rem',
+          flexWrap: 'wrap',
+        }}
+      >
         {regions.map((r) => (
           <a key={r} href={`/modules?region=${encodeURIComponent(r)}`}>
             <button>{r}</button>

--- a/pages/region/[region].js
+++ b/pages/region/[region].js
@@ -1,6 +1,7 @@
 import { useRouter } from 'next/router'
 import { useEffect, useState } from 'react'
 import { supabase } from '../../supabaseClient.js'
+import ProgressBar from '../../components/ProgressBar.js'
 
 export default function RegionPage() {
   const router = useRouter()
@@ -44,9 +45,7 @@ export default function RegionPage() {
     <div style={{ padding: '1rem' }}>
       <a href="/map">Back to Map</a>
       <h1>{region}</h1>
-      <p>
-        {completed} out of {total} modules completed
-      </p>
+      <ProgressBar totalModules={total} completedModules={completed} />
       <section style={{ marginTop: '1rem' }}>
         <h2>Modules</h2>
         <div style={{ display: 'flex', gap: '1rem', flexWrap: 'wrap' }}>


### PR DESCRIPTION
## Summary
- Create colorful "Learning with Turian" landing page with calls to map and avatar creation
- Add ProgressBar component and integrate progress tracking into map, region, and profile pages
- Implement route protection for authenticated areas and add global footer and custom 404 page

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68907a96593c83298894db24baf21ee1