### PR TITLE
feat: add admin dashboard and creation pages

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -5,6 +5,7 @@ import Footer from '../components/Footer.js'
 
 export default function MyApp({ Component, pageProps }) {
   const [avatarUrl, setAvatarUrl] = useState(null)
+  const [isAdmin, setIsAdmin] = useState(false)
   const router = useRouter()
 
   useEffect(() => {
@@ -15,10 +16,11 @@ export default function MyApp({ Component, pageProps }) {
       if (!user) return
       const { data } = await supabase
         .from('users')
-        .select('avatar_url')
+        .select('avatar_url, is_admin')
         .eq('id', user.id)
         .single()
       setAvatarUrl(data?.avatar_url || null)
+      setIsAdmin(data?.is_admin || false)
     }
     load()
   }, [])
@@ -59,6 +61,11 @@ export default function MyApp({ Component, pageProps }) {
           borderBottom: '1px solid #ccc',
         }}
       >
+        {isAdmin && (
+          <a href="/admin/dashboard" style={{ marginRight: '1rem' }}>
+            Admin
+          </a>
+        )}
         <a
           href="/profile"
           style={{

--- a/pages/admin/create-module.js
+++ b/pages/admin/create-module.js
@@ -1,0 +1,128 @@
+import { useEffect, useState } from 'react'
+import { useRouter } from 'next/router'
+import { supabase } from '../../supabaseClient.js'
+import { protectAdmin } from '../../lib/protectAdmin.js'
+import { createLearningModule } from '../../userFeatures.js'
+
+export default function CreateModule() {
+  const router = useRouter()
+  const [loading, setLoading] = useState(true)
+  const [regions, setRegions] = useState([])
+  const [quizzes, setQuizzes] = useState([])
+  const [form, setForm] = useState({
+    title: '',
+    description: '',
+    type: '',
+    region: '',
+    age_group: '',
+    quiz_id: '',
+    media_urls: '',
+  })
+
+  useEffect(() => {
+    async function load() {
+      const ok = await protectAdmin(router)
+      if (!ok) return
+      const [regRes, quizRes] = await Promise.all([
+        supabase.from('regions').select('id, name'),
+        supabase.from('quizzes').select('id, title'),
+      ])
+      setRegions(regRes.data || [])
+      setQuizzes(quizRes.data || [])
+      setLoading(false)
+    }
+    load()
+  }, [router])
+
+  const handleSubmit = async (e) => {
+    e.preventDefault()
+    let urls
+    try {
+      urls = form.media_urls ? JSON.parse(form.media_urls) : []
+    } catch (e) {
+      alert('Invalid media URLs JSON')
+      return
+    }
+    const module = {
+      title: form.title,
+      description: form.description,
+      content_type: form.type,
+      region: form.region,
+      age_group: form.age_group,
+      quiz_id: form.quiz_id || null,
+      media_urls: urls,
+    }
+    const { error } = await createLearningModule(module)
+    if (!error) {
+      router.push('/admin/dashboard')
+    }
+  }
+
+  if (loading) return <div>Loading...</div>
+
+  return (
+    <main style={{ padding: '1rem' }}>
+      <h1>Create Learning Module</h1>
+      <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+        <input
+          value={form.title}
+          onChange={(e) => setForm({ ...form, title: e.target.value })}
+          placeholder="Title"
+          required
+        />
+        <textarea
+          value={form.description}
+          onChange={(e) => setForm({ ...form, description: e.target.value })}
+          placeholder="Description"
+          required
+        />
+        <select
+          value={form.type}
+          onChange={(e) => setForm({ ...form, type: e.target.value })}
+          required
+        >
+          <option value="">Type</option>
+          <option value="storybook">Storybook</option>
+          <option value="video">Video</option>
+          <option value="game">Game</option>
+          <option value="other">Other</option>
+        </select>
+        <select
+          value={form.region}
+          onChange={(e) => setForm({ ...form, region: e.target.value })}
+          required
+        >
+          <option value="">Region</option>
+          {regions.map((r) => (
+            <option key={r.id} value={r.name}>
+              {r.name}
+            </option>
+          ))}
+        </select>
+        <input
+          value={form.age_group}
+          onChange={(e) => setForm({ ...form, age_group: e.target.value })}
+          placeholder="Age group"
+        />
+        <select
+          value={form.quiz_id}
+          onChange={(e) => setForm({ ...form, quiz_id: e.target.value })}
+        >
+          <option value="">Optional Quiz</option>
+          {quizzes.map((q) => (
+            <option key={q.id} value={q.id}>
+              {q.title}
+            </option>
+          ))}
+        </select>
+        <textarea
+          value={form.media_urls}
+          onChange={(e) => setForm({ ...form, media_urls: e.target.value })}
+          placeholder='Media URLs JSON (e.g. ["url1"])'
+        />
+        <button type="submit">Create Module</button>
+      </form>
+    </main>
+  )
+}
+

--- a/pages/admin/create-quiz.js
+++ b/pages/admin/create-quiz.js
@@ -1,0 +1,94 @@
+import { useEffect, useState } from 'react'
+import { useRouter } from 'next/router'
+import { supabase } from '../../supabaseClient.js'
+import { protectAdmin } from '../../lib/protectAdmin.js'
+
+export default function CreateQuiz() {
+  const router = useRouter()
+  const [loading, setLoading] = useState(true)
+  const [categories, setCategories] = useState([])
+  const [regions, setRegions] = useState([])
+  const [title, setTitle] = useState('')
+  const [description, setDescription] = useState('')
+  const [category, setCategory] = useState('')
+  const [region, setRegion] = useState('')
+  const [questions, setQuestions] = useState('')
+
+  useEffect(() => {
+    async function load() {
+      const ok = await protectAdmin(router)
+      if (!ok) return
+      const [catRes, regRes] = await Promise.all([
+        supabase.from('categories').select('id, name'),
+        supabase.from('regions').select('id, name'),
+      ])
+      setCategories(catRes.data || [])
+      setRegions(regRes.data || [])
+      setLoading(false)
+    }
+    load()
+  }, [router])
+
+  const handleSubmit = async (e) => {
+    e.preventDefault()
+    let parsed
+    try {
+      parsed = questions ? JSON.parse(questions) : []
+    } catch (e) {
+      alert('Invalid questions JSON')
+      return
+    }
+    const { error } = await supabase.from('quizzes').insert({
+      title,
+      description,
+      category,
+      region,
+      questions_data: parsed,
+    })
+    if (!error) {
+      router.push('/admin/dashboard')
+    }
+  }
+
+  if (loading) return <div>Loading...</div>
+
+  return (
+    <main style={{ padding: '1rem' }}>
+      <h1>Create Quiz</h1>
+      <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+        <input value={title} onChange={(e) => setTitle(e.target.value)} placeholder="Title" required />
+        <textarea
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          placeholder="Description"
+          required
+        />
+        <select value={category} onChange={(e) => setCategory(e.target.value)} required>
+          <option value="">Category</option>
+          {categories.map((c) => (
+            <option key={c.id} value={c.name}>
+              {c.name}
+            </option>
+          ))}
+        </select>
+        <select value={region} onChange={(e) => setRegion(e.target.value)} required>
+          <option value="">Region</option>
+          {regions.map((r) => (
+            <option key={r.id} value={r.name}>
+              {r.name}
+            </option>
+          ))}
+        </select>
+        <textarea
+          value={questions}
+          onChange={(e) => setQuestions(e.target.value)}
+          placeholder="Questions JSON"
+          rows={10}
+          required
+        />
+        <button type="submit">Create Quiz</button>
+      </form>
+    </main>
+  )
+}
+

--- a/pages/admin/dashboard.js
+++ b/pages/admin/dashboard.js
@@ -1,0 +1,80 @@
+import { useEffect, useState } from 'react'
+import { useRouter } from 'next/router'
+import { supabase } from '../../supabaseClient.js'
+import { protectAdmin } from '../../lib/protectAdmin.js'
+
+export default function AdminDashboard() {
+  const router = useRouter()
+  const [loading, setLoading] = useState(true)
+  const [stats, setStats] = useState({ users: 0, avatars: 0, quizzes: 0, stamps: 0 })
+  const [feedback, setFeedback] = useState([])
+
+  useEffect(() => {
+    async function load() {
+      const ok = await protectAdmin(router)
+      if (!ok) return
+      const [u, a, q, s, f] = await Promise.all([
+        supabase.from('users').select('id', { count: 'exact', head: true }),
+        supabase.from('avatars').select('id', { count: 'exact', head: true }),
+        supabase.from('quizzes').select('id', { count: 'exact', head: true }),
+        supabase.from('stamps').select('id', { count: 'exact', head: true }),
+        supabase
+          .from('feedback')
+          .select('*')
+          .order('created_at', { ascending: false })
+          .limit(5),
+      ])
+      setStats({
+        users: u.count || 0,
+        avatars: a.count || 0,
+        quizzes: q.count || 0,
+        stamps: s.count || 0,
+      })
+      setFeedback(f.data || [])
+      setLoading(false)
+    }
+    load()
+  }, [router])
+
+  if (loading) return <div>Loading...</div>
+
+  const cardStyle = {
+    border: '1px solid #ccc',
+    padding: '1rem',
+    borderRadius: '8px',
+    flex: '1',
+    minWidth: '150px',
+    textAlign: 'center',
+  }
+
+  return (
+    <main style={{ padding: '1rem' }}>
+      <h1>Admin Dashboard</h1>
+      <div style={{ display: 'flex', gap: '1rem', flexWrap: 'wrap', marginBottom: '2rem' }}>
+        <div style={cardStyle}>
+          <div>Total Users</div>
+          <div style={{ fontSize: '2rem' }}>{stats.users}</div>
+        </div>
+        <div style={cardStyle}>
+          <div>Total Avatars</div>
+          <div style={{ fontSize: '2rem' }}>{stats.avatars}</div>
+        </div>
+        <div style={cardStyle}>
+          <div>Quizzes Created</div>
+          <div style={{ fontSize: '2rem' }}>{stats.quizzes}</div>
+        </div>
+        <div style={cardStyle}>
+          <div>Stamps Earned</div>
+          <div style={{ fontSize: '2rem' }}>{stats.stamps}</div>
+        </div>
+      </div>
+      <h2>Recent Feedback</h2>
+      <ul>
+        {feedback.map((f) => (
+          <li key={f.id}>{f.message}</li>
+        ))}
+      </ul>
+    </main>
+  )
+}
+


### PR DESCRIPTION
## Summary
- add new admin dashboard with user, avatar, quiz, and stamp stats plus recent feedback
- introduce quiz and learning module creation pages for admins
- show Admin link in global navbar when signed-in user is an admin

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68907c569d0c83299734d98b047b091e