### PR TITLE
Add leaderboard and guest enhancements

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -65,14 +65,21 @@ export async function signOut() {
   await supabase.auth.signOut()
 }
 
-export function signInAsGuest() {
+export async function signInAsGuest() {
   const id = crypto.randomUUID()
   const guestUser = {
     id,
-    username: `Guest_${Math.floor(Math.random() * 10000)}`,
+    username: `Guest-${Math.floor(Math.random() * 9000) + 1000}`,
     avatar_url: 'https://placehold.co/100x100',
     isGuest: true,
   }
+  const { error } = await supabase.from('users').upsert({
+    id,
+    username: guestUser.username,
+    avatar_url: guestUser.avatar_url,
+    is_guest: true,
+  })
+  if (error) console.error('Error creating guest user:', error)
   sessionStorage.setItem('guest_user', JSON.stringify(guestUser))
   return guestUser
 }

--- a/components/Footer.js
+++ b/components/Footer.js
@@ -10,15 +10,33 @@ export default function Footer() {
         background: '#f8f8f8',
       }}
     >
-      <div style={{ marginBottom: '0.5rem', display: 'flex', justifyContent: 'center', gap: '1rem', flexWrap: 'wrap' }}>
-        <a href="/">Home</a>
-        <a href="/map">Map</a>
-        <a href="/profile">Profile</a>
-        <a href="/learning-with-turian">Learn</a>
+      <div
+        style={{
+          marginBottom: '0.5rem',
+          display: 'flex',
+          justifyContent: 'center',
+          gap: '1rem',
+          flexWrap: 'wrap',
+        }}
+      >
+        <a href="/about">About Naturverse</a>
+        <a href="/contact">Contact</a>
+        <a href="/terms">Terms</a>
+        <a href="/privacy">Privacy</a>
       </div>
-      <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', gap: '0.5rem' }}>
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
+          gap: '0.5rem',
+          flexWrap: 'wrap',
+        }}
+      >
         <img src="/logo.png" alt="Turian logo" style={{ height: '24px' }} />
-        <span style={{ fontSize: '0.875rem' }}>© Turian Media</span>
+        <span style={{ fontSize: '0.875rem' }}>
+          Powered by Turian Media Company
+        </span>
       </div>
     </footer>
   )

--- a/components/StampShowcase.js
+++ b/components/StampShowcase.js
@@ -1,0 +1,61 @@
+import { useEffect, useState } from 'react'
+
+export default function StampShowcase({ stamp, onClose }) {
+  const [visible, setVisible] = useState(false)
+
+  useEffect(() => {
+    if (stamp) setVisible(true)
+  }, [stamp])
+
+  if (!stamp || !visible) return null
+
+  const handleClose = () => {
+    setVisible(false)
+    if (onClose) onClose()
+  }
+
+  return (
+    <div
+      onClick={handleClose}
+      style={{
+        position: 'fixed',
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 0,
+        background: 'rgba(0,0,0,0.5)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        zIndex: 1000,
+      }}
+    >
+      <div
+        style={{
+          background: '#fff',
+          padding: '1rem',
+          borderRadius: '8px',
+          textAlign: 'center',
+          animation: 'pop 0.3s ease',
+        }}
+      >
+        <div style={{ fontSize: '2rem' }}>🎉</div>
+        <h2>New Stamp Earned!</h2>
+        <p>{stamp.name}</p>
+        <p>{stamp.region}</p>
+        <p>{new Date(stamp.created_at).toLocaleDateString()}</p>
+      </div>
+      <style jsx>{`
+        @keyframes pop {
+          from {
+            transform: scale(0.5);
+          }
+          to {
+            transform: scale(1);
+          }
+        }
+      `}</style>
+    </div>
+  )
+}
+

--- a/pages/leaderboard.js
+++ b/pages/leaderboard.js
@@ -1,0 +1,108 @@
+import { useEffect, useState } from 'react'
+import { supabase } from '../supabaseClient.js'
+
+export default function LeaderboardPage() {
+  const [mostAttempts, setMostAttempts] = useState([])
+  const [highestAverage, setHighestAverage] = useState([])
+  const [mostStamps, setMostStamps] = useState([])
+
+  useEffect(() => {
+    async function load() {
+      const { data: attemptsData } = await supabase
+        .from('user_quiz_attempts')
+        .select('user_id, score, users(username, avatar_url)')
+      const attemptsMap = {}
+      attemptsData?.forEach((a) => {
+        if (!attemptsMap[a.user_id]) {
+          attemptsMap[a.user_id] = {
+            id: a.user_id,
+            username: a.users?.username,
+            avatar_url: a.users?.avatar_url,
+            attempts: 0,
+            totalScore: 0,
+          }
+        }
+        attemptsMap[a.user_id].attempts += 1
+        attemptsMap[a.user_id].totalScore += a.score || 0
+      })
+      const attemptArr = Object.values(attemptsMap).map((item) => ({
+        ...item,
+        avgScore: item.attempts ? item.totalScore / item.attempts : 0,
+      }))
+      setMostAttempts(
+        [...attemptArr].sort((a, b) => b.attempts - a.attempts).slice(0, 10)
+      )
+      setHighestAverage(
+        [...attemptArr].sort((a, b) => b.avgScore - a.avgScore).slice(0, 10)
+      )
+
+      const { data: stampsData } = await supabase
+        .from('stamps')
+        .select('user_id, users(username, avatar_url)')
+      const stampMap = {}
+      stampsData?.forEach((s) => {
+        if (!stampMap[s.user_id]) {
+          stampMap[s.user_id] = {
+            id: s.user_id,
+            username: s.users?.username,
+            avatar_url: s.users?.avatar_url,
+            count: 0,
+          }
+        }
+        stampMap[s.user_id].count += 1
+      })
+      const stampArr = Object.values(stampMap)
+      setMostStamps(
+        stampArr.sort((a, b) => b.count - a.count).slice(0, 10)
+      )
+    }
+    load()
+  }, [])
+
+  const renderList = (items, valueKey) => (
+    <ol>
+      {items.map((item) => (
+        <li
+          key={item.id}
+          style={{ display: 'flex', alignItems: 'center', marginBottom: '0.5rem' }}
+        >
+          <img
+            src={item.avatar_url || '/logo.png'}
+            alt="avatar"
+            style={{
+              width: 32,
+              height: 32,
+              borderRadius: '50%',
+              marginRight: '0.5rem',
+              objectFit: 'cover',
+            }}
+          />
+          <span style={{ marginRight: '0.5rem' }}>{item.username}</span>
+          <span>{item[valueKey]}</span>
+        </li>
+      ))}
+    </ol>
+  )
+
+  return (
+    <div style={{ padding: '1rem' }}>
+      <h1>Leaderboard</h1>
+      <section>
+        <h2>Most Quiz Attempts</h2>
+        {renderList(mostAttempts, 'attempts')}
+      </section>
+      <section>
+        <h2>Highest Average Quiz Score</h2>
+        {renderList(
+          highestAverage.map((i) => ({ ...i, avg: i.avgScore.toFixed(2) })),
+          'avg'
+        )}
+      </section>
+      <section>
+        <h2>Most Stamps Earned</h2>
+        {renderList(mostStamps, 'count')}
+      </section>
+    </div>
+  )
+}
+


### PR DESCRIPTION
## Summary
- add public leaderboard page with top users by quiz attempts, scores, and stamps
- expose leaderboard in global nav and warn guests to create accounts
- support guest users in Supabase, show stamp showcase, and update footer links

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68907e5a609083298de99af451dbd361