### PR TITLE
feat: add loading states and esm compliance

### DIFF
--- a/pages/admin-feedback.js
+++ b/pages/admin-feedback.js
@@ -11,6 +11,7 @@ export default function AdminFeedback() {
   const pageSize = 20
   const [page, setPage] = useState(0)
   const [hasMore, setHasMore] = useState(true)
+  const [loadingMore, setLoadingMore] = useState(false)
 
   useEffect(() => {
     async function load() {
@@ -29,6 +30,7 @@ export default function AdminFeedback() {
   }, [router])
 
   const loadMore = async () => {
+    setLoadingMore(true)
     const from = (page + 1) * pageSize
     const to = from + pageSize - 1
     const { data } = await supabase
@@ -43,6 +45,7 @@ export default function AdminFeedback() {
     } else {
       setHasMore(false)
     }
+    setLoadingMore(false)
   }
 
   if (loading) return <div>Loading...</div>
@@ -75,8 +78,12 @@ export default function AdminFeedback() {
           </table>
         </div>
         {hasMore && (
-          <button onClick={loadMore} style={{ marginTop: '1rem' }}>
-            Load More
+          <button
+            onClick={loadMore}
+            style={{ marginTop: '1rem' }}
+            disabled={loadingMore}
+          >
+            {loadingMore ? 'Loading...' : 'Load More'}
           </button>
         )}
       </main>

--- a/pages/admin-module-uploader.js
+++ b/pages/admin-module-uploader.js
@@ -19,6 +19,7 @@ export default function AdminModuleUploader() {
     quiz_id: '',
     files: [],
   })
+  const [uploading, setUploading] = useState(false)
 
   useEffect(() => {
     async function load() {
@@ -37,6 +38,7 @@ export default function AdminModuleUploader() {
 
   const handleSubmit = async (e) => {
     e.preventDefault()
+    setUploading(true)
     const uploads = []
     for (const file of form.files) {
       const filePath = `${Date.now()}_${file.name}`
@@ -68,6 +70,7 @@ export default function AdminModuleUploader() {
         files: [],
       })
     }
+    setUploading(false)
   }
 
   if (loading) return <div>Loading...</div>
@@ -134,7 +137,9 @@ export default function AdminModuleUploader() {
             multiple
             onChange={(e) => setForm({ ...form, files: e.target.files })}
           />
-          <button type="submit">Upload</button>
+          <button type="submit" disabled={uploading}>
+            {uploading ? 'Uploading...' : 'Upload'}
+          </button>
         </form>
       </main>
     </div>

--- a/pages/admin-notifications.js
+++ b/pages/admin-notifications.js
@@ -12,6 +12,7 @@ export default function AdminNotifications() {
   const [title, setTitle] = useState('')
   const [message, setMessage] = useState('')
   const [target, setTarget] = useState('all')
+  const [submitting, setSubmitting] = useState(false)
 
   useEffect(() => {
     async function load() {
@@ -33,6 +34,7 @@ export default function AdminNotifications() {
 
   const handleSubmit = async (e) => {
     e.preventDefault()
+    setSubmitting(true)
     const payloads = []
     if (target === 'all') {
       payloads.push(
@@ -64,6 +66,7 @@ export default function AdminNotifications() {
     setTitle('')
     setMessage('')
     setTarget('all')
+    setSubmitting(false)
   }
 
   if (loading) return <div>Loading...</div>
@@ -102,7 +105,9 @@ export default function AdminNotifications() {
               ))}
             </select>
           </div>
-          <button type="submit">Send</button>
+          <button type="submit" disabled={submitting}>
+            {submitting ? 'Submitting...' : 'Send'}
+          </button>
         </form>
         <ul style={{ listStyle: 'none', padding: 0 }}>
           {notifications.map((n) => (

--- a/pages/admin-quiz-editor.js
+++ b/pages/admin-quiz-editor.js
@@ -11,6 +11,7 @@ export default function AdminQuizEditor() {
   const [selected, setSelected] = useState(null)
   const [title, setTitle] = useState('')
   const [json, setJson] = useState('')
+  const [saving, setSaving] = useState(false)
 
   useEffect(() => {
     async function load() {
@@ -46,6 +47,7 @@ export default function AdminQuizEditor() {
       alert('Invalid JSON')
       return
     }
+    setSaving(true)
     if (selected) {
       const { error } = await supabase
         .from('quizzes')
@@ -67,6 +69,7 @@ export default function AdminQuizEditor() {
         setSelected(data)
       }
     }
+    setSaving(false)
   }
 
   if (loading) return <div>Loading...</div>
@@ -107,8 +110,12 @@ export default function AdminQuizEditor() {
                 placeholder="Questions JSON"
               />
             </div>
-            <button onClick={handleSave} style={{ marginTop: '1rem' }}>
-              Save
+            <button
+              onClick={handleSave}
+              style={{ marginTop: '1rem' }}
+              disabled={saving}
+            >
+              {saving ? 'Saving...' : 'Save'}
             </button>
           </section>
         </div>

--- a/pages/admin-regions.js
+++ b/pages/admin-regions.js
@@ -10,6 +10,8 @@ export default function AdminRegions() {
   const [usedRegions, setUsedRegions] = useState([])
   const [regions, setRegions] = useState([])
   const [newRegion, setNewRegion] = useState({ name: '', color: '', icon_url: '' })
+  const [adding, setAdding] = useState(false)
+  const [savingId, setSavingId] = useState(null)
 
   useEffect(() => {
     async function load() {
@@ -42,6 +44,7 @@ export default function AdminRegions() {
 
   const saveRegion = async (id) => {
     const region = regions.find((r) => r.id === id)
+    setSavingId(id)
     const { data, error } = await supabase
       .from('regions')
       .update({ color: region.color, icon_url: region.icon_url })
@@ -51,10 +54,12 @@ export default function AdminRegions() {
     if (!error) {
       setRegions((prev) => prev.map((r) => (r.id === id ? data : r)))
     }
+    setSavingId(null)
   }
 
   const addRegion = async (e) => {
     e.preventDefault()
+    setAdding(true)
     const { data, error } = await supabase
       .from('regions')
       .insert(newRegion)
@@ -64,6 +69,7 @@ export default function AdminRegions() {
       setRegions((prev) => [...prev, data])
       setNewRegion({ name: '', color: '', icon_url: '' })
     }
+    setAdding(false)
   }
 
   if (loading) return <div>Loading...</div>
@@ -100,7 +106,9 @@ export default function AdminRegions() {
               onChange={(e) => setNewRegion({ ...newRegion, icon_url: e.target.value })}
               placeholder="Icon URL"
             />
-            <button type="submit">Add</button>
+            <button type="submit" disabled={adding}>
+              {adding ? 'Adding...' : 'Add'}
+            </button>
           </form>
           <div style={{ marginTop: '1rem' }}>
             {regions.map((r) => (
@@ -118,8 +126,12 @@ export default function AdminRegions() {
                   placeholder="Icon URL"
                   style={{ marginLeft: '0.5rem' }}
                 />
-                <button onClick={() => saveRegion(r.id)} style={{ marginLeft: '0.5rem' }}>
-                  Save
+                <button
+                  onClick={() => saveRegion(r.id)}
+                  style={{ marginLeft: '0.5rem' }}
+                  disabled={savingId === r.id}
+                >
+                  {savingId === r.id ? 'Saving...' : 'Save'}
                 </button>
               </div>
             ))}

--- a/pages/admin/badges.js
+++ b/pages/admin/badges.js
@@ -9,6 +9,7 @@ export default function AdminBadges() {
   const [userId, setUserId] = useState('')
   const [region, setRegion] = useState(regions[0])
   const [status, setStatus] = useState('')
+  const [granting, setGranting] = useState(false)
 
   useEffect(() => {
     async function load() {
@@ -31,12 +32,14 @@ export default function AdminBadges() {
 
   const grant = async () => {
     if (!userId) return
+    setGranting(true)
     const { error } = await supabase.from('stamps').insert({
       user_id: userId,
       region,
       stamp_name: `${region} Badge`,
     })
     setStatus(error ? 'Error granting stamp' : 'Stamp granted!')
+    setGranting(false)
   }
 
   if (!allowed) return <div>{status}</div>
@@ -63,7 +66,9 @@ export default function AdminBadges() {
           ))}
         </select>
       </div>
-      <button onClick={grant}>Grant Stamp</button>
+      <button onClick={grant} disabled={granting}>
+        {granting ? 'Granting...' : 'Grant Stamp'}
+      </button>
       {status && <p>{status}</p>}
     </div>
   )

--- a/pages/admin/create-module.js
+++ b/pages/admin/create-module.js
@@ -18,6 +18,7 @@ export default function CreateModule() {
     quiz_id: '',
     media_urls: '',
   })
+  const [submitting, setSubmitting] = useState(false)
 
   useEffect(() => {
     async function load() {
@@ -36,11 +37,13 @@ export default function CreateModule() {
 
   const handleSubmit = async (e) => {
     e.preventDefault()
+    setSubmitting(true)
     let urls
     try {
       urls = form.media_urls ? JSON.parse(form.media_urls) : []
     } catch (e) {
       alert('Invalid media URLs JSON')
+      setSubmitting(false)
       return
     }
     const module = {
@@ -56,6 +59,7 @@ export default function CreateModule() {
     if (!error) {
       router.push('/admin/dashboard')
     }
+    setSubmitting(false)
   }
 
   if (loading) return <div>Loading...</div>
@@ -120,7 +124,9 @@ export default function CreateModule() {
           onChange={(e) => setForm({ ...form, media_urls: e.target.value })}
           placeholder='Media URLs JSON (e.g. ["url1"])'
         />
-        <button type="submit">Create Module</button>
+        <button type="submit" disabled={submitting}>
+          {submitting ? 'Submitting...' : 'Create Module'}
+        </button>
       </form>
     </main>
   )

--- a/pages/admin/create-quiz.js
+++ b/pages/admin/create-quiz.js
@@ -13,6 +13,7 @@ export default function CreateQuiz() {
   const [category, setCategory] = useState('')
   const [region, setRegion] = useState('')
   const [questions, setQuestions] = useState('')
+  const [submitting, setSubmitting] = useState(false)
 
   useEffect(() => {
     async function load() {
@@ -31,11 +32,13 @@ export default function CreateQuiz() {
 
   const handleSubmit = async (e) => {
     e.preventDefault()
+    setSubmitting(true)
     let parsed
     try {
       parsed = questions ? JSON.parse(questions) : []
     } catch (e) {
       alert('Invalid questions JSON')
+      setSubmitting(false)
       return
     }
     const { error } = await supabase.from('quizzes').insert({
@@ -48,6 +51,7 @@ export default function CreateQuiz() {
     if (!error) {
       router.push('/admin/dashboard')
     }
+    setSubmitting(false)
   }
 
   if (loading) return <div>Loading...</div>
@@ -86,7 +90,9 @@ export default function CreateQuiz() {
           rows={10}
           required
         />
-        <button type="submit">Create Quiz</button>
+        <button type="submit" disabled={submitting}>
+          {submitting ? 'Submitting...' : 'Create Quiz'}
+        </button>
       </form>
     </main>
   )

--- a/pages/profile.js
+++ b/pages/profile.js
@@ -118,6 +118,7 @@ export default function ProfilePage() {
         </div>
         <div style={{ margin: '1rem 0' }}>
           <input type="file" onChange={handleAvatar} disabled={uploading} />
+          {uploading && <p>Uploading...</p>}
         </div>
         <div style={{ marginBottom: '0.5rem' }}>
           <label>Username</label>


### PR DESCRIPTION
## Summary
- add loading indicator for avatar uploads on profile page
- add loading states across admin forms (quiz/module creation, module uploader, region & badge management, notifications, feedback, quiz editor)
- confirm ES module usage with package.json `type: module`

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689085759bc0832980e21cb0510a3ed1