### PR TITLE
Add email waitlist form with Supabase integration

### DIFF
--- a/emailCapture.js
+++ b/emailCapture.js
@@ -1,0 +1,28 @@
+import { supabase } from './supabaseClient.js'
+
+document.addEventListener('DOMContentLoaded', () => {
+  const form = document.getElementById('email-form')
+  const messageDiv = document.getElementById('form-message')
+  if (!form || !messageDiv) return
+
+  form.addEventListener('submit', async (event) => {
+    event.preventDefault()
+    const emailInput = form.querySelector('#email')
+    const email = emailInput.value.trim()
+
+    if (!email) {
+      messageDiv.textContent = 'Please enter your email.'
+      return
+    }
+
+    const { error } = await supabase.from('early_access_waitlist').insert({ email })
+
+    if (error) {
+      messageDiv.textContent = 'There was an error. Please try again.'
+      return
+    }
+
+    form.reset()
+    messageDiv.textContent = 'Thanks! You\'re on the list.'
+  })
+})

--- a/index.html
+++ b/index.html
@@ -95,6 +95,14 @@
 
   <div id="result" style="margin-top: 20px;"></div>
 
+  <form id="email-form" style="margin-top: 20px;">
+    <label for="email">Email:</label>
+    <input type="email" id="email" placeholder="Enter your email" />
+    <button type="submit">Notify Me</button>
+  </form>
+  <div id="form-message"></div>
+
   <script type="module" src="index.js"></script>
+  <script type="module" src="./emailCapture.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add early access form and feedback message on landing page
- capture email addresses and store via Supabase in `early_access_waitlist`

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68916c4f3b108329a92b25f46c5a2c1d