### PR TITLE
Add basic form validation and submit button feedback

### DIFF
--- a/emailCapture.js
+++ b/emailCapture.js
@@ -3,25 +3,36 @@ import { supabase } from './supabaseClient.js'
 document.addEventListener('DOMContentLoaded', () => {
   const form = document.getElementById('email-form')
   const messageDiv = document.getElementById('form-message')
-  if (!form || !messageDiv) return
+  const submitBtn = document.getElementById('submitBtn')
+  if (!form || !messageDiv || !submitBtn) return
 
   form.addEventListener('submit', async (event) => {
     event.preventDefault()
-    const emailInput = form.querySelector('#email')
-    const email = emailInput.value.trim()
-    const name = document.getElementById('name').value
-    const age_group = document.getElementById('age_group').value
-    const interest = document.getElementById('interest').value
-    const message = document.getElementById('message').value
+    const email = document.getElementById('email').value.trim()
+    const name = document.getElementById('name').value.trim()
+    const age_group = document.getElementById('age_group').value.trim()
+    const interest = document.getElementById('interest').value.trim()
+    const message = document.getElementById('message').value.trim()
 
-    if (!email) {
-      messageDiv.textContent = 'Please enter your email.'
+    if (!name || !email || !age_group) {
+      alert('Please fill in your name, email, and age group.')
       return
     }
 
-    const { error } = await supabase
-      .from('early_access_waitlist')
-      .insert({ email, name, age_group, interest, message })
+    submitBtn.disabled = true
+    submitBtn.innerText = 'Submitting...'
+
+    let error
+    try {
+      ;({ error } = await supabase
+        .from('early_access_waitlist')
+        .insert({ email, name, age_group, interest, message }))
+    } catch (e) {
+      error = e
+    }
+
+    submitBtn.disabled = false
+    submitBtn.innerText = 'Join Waitlist'
 
     if (error) {
       messageDiv.textContent = 'There was an error. Please try again.'

--- a/index.html
+++ b/index.html
@@ -107,7 +107,7 @@
       <textarea id="message" placeholder="Anything else to share?"></textarea>
       <label for="email">Email:</label>
       <input type="email" id="email" placeholder="Enter your email" />
-      <button type="submit">Notify Me</button>
+      <button id="submitBtn" type="submit">Join Waitlist</button>
     </form>
   <div id="form-message"></div>
 


### PR DESCRIPTION
## Summary
- Require name, email, and age group before submitting waitlist form
- Disable submit button with temporary loading text while request is processed
- Add dedicated submit button identifier in HTML

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689170240dfc832984074750b2dc3bb7