### PR TITLE
Add success message after waitlist signup

### DIFF
--- a/emailCapture.js
+++ b/emailCapture.js
@@ -1,10 +1,12 @@
 import { supabase } from './supabaseClient.js'
 
 document.addEventListener('DOMContentLoaded', () => {
+  const formContainer = document.getElementById('email-form-container')
   const form = document.getElementById('email-form')
   const messageDiv = document.getElementById('form-message')
+  const successMessage = document.getElementById('success-message')
   const submitBtn = document.getElementById('submitBtn')
-  if (!form || !messageDiv || !submitBtn) return
+  if (!form || !messageDiv || !submitBtn || !formContainer || !successMessage) return
 
   form.addEventListener('submit', async (event) => {
     event.preventDefault()
@@ -40,7 +42,9 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     form.reset()
-    messageDiv.textContent = 'Thanks! You\'re on the list.'
-    alert("Thanks for joining the waitlist! We'll be in touch soon.")
+    formContainer.style.display = 'none'
+    successMessage.style.display = 'block'
+    // To redirect to a thank-you page instead of showing a message, use:
+    // window.location.href = '/thank-you.html'
   })
 })

--- a/index.html
+++ b/index.html
@@ -95,7 +95,8 @@
 
   <div id="result" style="margin-top: 20px;"></div>
 
-    <form id="email-form" style="margin-top: 20px;">
+  <div id="email-form-container" style="margin-top: 20px;">
+    <form id="email-form">
       <input type="text" id="name" placeholder="Full Name" />
       <select id="age_group">
         <option value="Child">Child</option>
@@ -109,7 +110,11 @@
       <input type="email" id="email" placeholder="Enter your email" />
       <button id="submitBtn" type="submit">Join Waitlist</button>
     </form>
-  <div id="form-message"></div>
+    <div id="form-message"></div>
+  </div>
+  <div id="success-message" style="display: none; margin-top: 20px;">
+    <p>Thanks! You're on the list.</p>
+  </div>
 
   <script type="module" src="index.js"></script>
   <script type="module" src="./emailCapture.js"></script>


### PR DESCRIPTION
## Summary
- wrap waitlist form in a container and add hidden success message section
- toggle form and success message display on submission and include optional redirect logic

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_6891739ff354832994b21690868f60d1