### PR TITLE
feat: add subscribe api route

### DIFF
--- a/pages/api/subscribe.js
+++ b/pages/api/subscribe.js
@@ -1,0 +1,9 @@
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', ['POST']);
+    return res.status(405).end('Method Not Allowed');
+  }
+  const { email, options } = req.body || {};
+  console.log('Received subscription data:', { email, options });
+  return res.status(200).json({ message: 'Subscription received', email, options });
+}


### PR DESCRIPTION
## Summary
- add API route to handle subscription form submissions

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68917dcd09548329bf993bc4e8458ddf