### PR TITLE
feat: post email and options to subscribe api

### DIFF
--- a/components/EmailCaptureForm.js
+++ b/components/EmailCaptureForm.js
@@ -2,12 +2,34 @@ import { useState } from 'react'
 
 export default function EmailCaptureForm() {
   const [email, setEmail] = useState('')
+  const [options, setOptions] = useState({
+    newsletter: false,
+    updates: false,
+  })
   const [submitted, setSubmitted] = useState(false)
+  const [error, setError] = useState('')
 
-  const handleSubmit = (e) => {
+  const handleOptionChange = (e) => {
+    const { name, checked } = e.target
+    setOptions((prev) => ({ ...prev, [name]: checked }))
+  }
+
+  const handleSubmit = async (e) => {
     e.preventDefault()
-    console.log(email)
-    setSubmitted(true)
+    setError('')
+    const selectedOptions = Object.keys(options).filter((key) => options[key])
+    try {
+      const res = await fetch('/api/subscribe', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, options: selectedOptions }),
+      })
+      if (!res.ok) throw new Error('Network response was not ok')
+      setSubmitted(true)
+    } catch (err) {
+      console.error(err)
+      setError('Something went wrong. Please try again.')
+    }
   }
 
   if (submitted) {
@@ -37,6 +59,25 @@ export default function EmailCaptureForm() {
           required
         />
       </label>
+      <label className="checkbox">
+        <input
+          type="checkbox"
+          name="newsletter"
+          checked={options.newsletter}
+          onChange={handleOptionChange}
+        />
+        Newsletter
+      </label>
+      <label className="checkbox">
+        <input
+          type="checkbox"
+          name="updates"
+          checked={options.updates}
+          onChange={handleOptionChange}
+        />
+        Product Updates
+      </label>
+      {error && <p className="error">{error}</p>}
       <button type="submit">Sign Up</button>
       <style jsx>{`
         .email-form {
@@ -51,10 +92,18 @@ export default function EmailCaptureForm() {
           flex-direction: column;
           font-weight: 500;
         }
-        input {
+        .checkbox {
+          flex-direction: row;
+          align-items: center;
+        }
+        input[type='email'] {
           padding: 0.5rem;
           border: 1px solid #ccc;
           border-radius: 4px;
+        }
+        .error {
+          color: red;
+          font-size: 0.9rem;
         }
         button {
           padding: 0.5rem 1rem;


### PR DESCRIPTION
## Summary
- collect email and newsletter/product update preferences
- POST subscription data to `/api/subscribe`
- show success or error after submitting

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68917effbbe083299e0e5fa7c8bd8dd7