### PR TITLE
Add confirmation email handler

### DIFF
--- a/send-confirmation/index.ts
+++ b/send-confirmation/index.ts
@@ -1,0 +1,30 @@
+import { serve } from "https://deno.land/std@0.177.0/http/server.ts";
+import { Resend } from "npm:resend";
+
+const resend = new Resend(Deno.env.get('RESEND_API_KEY') || "");
+
+serve(async (req: Request): Promise<Response> => {
+  try {
+    const { email, name, selectedOption } = await req.json();
+
+    await resend.emails.send({
+      from: "naturverse@yourdomain.com",
+      to: email,
+      subject: "🌱 Welcome to The Naturverse!",
+      html: `<p>Hello ${name},</p><p>Thank you for joining the waitlist with the option: ${selectedOption}.</p>`,
+    });
+
+    return new Response(JSON.stringify({ success: true }), {
+      headers: { "Content-Type": "application/json" },
+    });
+  } catch (error) {
+    console.error(error);
+    return new Response(
+      JSON.stringify({ error: (error as Error).message }),
+      {
+        status: 500,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+  }
+});


### PR DESCRIPTION
## Summary
- add Deno serverless function for confirmation emails via Resend

## Testing
- `npm test` *(fails: Missing script: "test")*
- `deno lint send-confirmation/index.ts` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689181f53f808329ab6c7e395b64b91a