### PR TITLE
feat: send confirmation email via Resend

### DIFF
--- a/supabase/functions/send-confirmation.ts
+++ b/supabase/functions/send-confirmation.ts
@@ -5,28 +5,31 @@ const resend = new Resend(process.env.RESEND_API_KEY || "");
 
 export async function POST(req: NextRequest) {
   try {
-    const { email, name, selectedOption } = await req.json();
+    const { email, name } = await req.json();
 
-    const { data, error } = await resend.emails.send({
+    const { error } = await resend.emails.send({
       from: "Naturverse <noreply@naturverse.com>",
       to: email,
       subject: "Thanks for joining the Naturverse!",
-      html: `<p>Hi ${name},</p><p>Thanks for joining the waitlist with the option: ${selectedOption}.</p>`,
+      html: `<p>Hi ${name},</p><p>Thanks for joining the waitlist.</p>`,
     });
 
     if (error) {
       return NextResponse.json(
-        { status: "error", message: error.message },
+        { error: error.message },
         { status: 500 },
       );
     }
 
-    return NextResponse.json({ status: "success", id: data?.id });
+    return NextResponse.json(
+      { message: "Confirmation email sent" },
+      { status: 200 },
+    );
   } catch (err) {
     console.error(err);
     return NextResponse.json(
-      { status: "error", message: (err as Error).message },
-      { status: 400 },
+      { error: (err as Error).message },
+      { status: 500 },
     );
   }
 }


### PR DESCRIPTION
## Summary
- send confirmation email using Resend from POST request

## Testing
- `npm test` (fails: Missing script: "test")

------
https://chatgpt.com/codex/tasks/task_e_68918b69a908832981623dc4990a822b