### PR TITLE
feat: add TypeScript subscription API

### DIFF
--- a/pages/api/subscribe.ts
+++ b/pages/api/subscribe.ts
@@ -1,0 +1,33 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', ['POST']);
+    return res.status(405).json({ error: 'Method Not Allowed' });
+  }
+
+  try {
+    const { name, email } = req.body || {};
+
+    if (!name || !email) {
+      return res.status(400).json({ error: 'Name and email are required' });
+    }
+
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!emailRegex.test(email)) {
+      return res.status(400).json({ error: 'Invalid email format' });
+    }
+
+    console.log('Received subscription data:', { name, email });
+    // TODO: Store the subscription data or integrate with email service
+
+    return res.status(200).json({ message: 'Subscription received' });
+  } catch (error) {
+    console.error('Subscription error:', error);
+    return res.status(400).json({ error: 'Unable to process subscription' });
+  }
+}
+


### PR DESCRIPTION
## Summary
- add `/api/subscribe` TypeScript handler validating name and email

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68918e1b4c008329abf06852835d7faf