### PR TITLE
feat: improve email capture submission handling

### DIFF
--- a/components/EmailCaptureForm.tsx
+++ b/components/EmailCaptureForm.tsx
@@ -4,6 +4,7 @@ export default function EmailCaptureForm() {
   const [email, setEmail] = useState('')
   const [name, setName] = useState('')
   const [status, setStatus] = useState({ type: '', message: '' })
+  const [loading, setLoading] = useState(false)
 
   useEffect(() => {
     if (status.message) {
@@ -14,6 +15,7 @@ export default function EmailCaptureForm() {
 
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault()
+    setLoading(true)
     try {
       const res = await fetch('/api/subscribe', {
         method: 'POST',
@@ -28,6 +30,8 @@ export default function EmailCaptureForm() {
     } catch (err) {
       console.error(err)
       setStatus({ type: 'error', message: 'Failed to subscribe. Please try again.' })
+    } finally {
+      setLoading(false)
     }
   }
 
@@ -47,7 +51,9 @@ export default function EmailCaptureForm() {
         onChange={(e) => setEmail(e.target.value)}
         required
       />
-      <button type="submit">Subscribe</button>
+      <button type="submit" disabled={loading}>
+        {loading ? 'Submitting...' : 'Subscribe'}
+      </button>
       {status.message && <p className={status.type}>{status.message}</p>}
     </form>
   )


### PR DESCRIPTION
## Summary
- manage loading state during email capture submissions
- display submission status and disable button while processing

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68918f43b7d88329931c4acde59f977b