### PR TITLE
feat: add Supabase email signup API

### DIFF
--- a/pages/api/subscribe.js
+++ b/pages/api/subscribe.js
@@ -1,9 +1,0 @@
-export default async function handler(req, res) {
-  if (req.method !== 'POST') {
-    res.setHeader('Allow', ['POST']);
-    return res.status(405).end('Method Not Allowed');
-  }
-  const { email, options } = req.body || {};
-  console.log('Received subscription data:', { email, options });
-  return res.status(200).json({ message: 'Subscription received', email, options });
-}


### PR DESCRIPTION
## Summary
- replace duplicate subscribe route with a TypeScript API handler
- save newsletter signups to Supabase `email_signups` table

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_6891907da7948329aa718ef557f27a81