### PR TITLE
Store waitlist form data and show submission success

### DIFF
--- a/emailCapture.js
+++ b/emailCapture.js
@@ -10,9 +10,13 @@ document.addEventListener('DOMContentLoaded', () => {
 
   form.addEventListener('submit', async (event) => {
     event.preventDefault()
-    const email = document.getElementById('email').value.trim()
+    const email = document.getElementById('waitlist-email').value.trim()
+    const name = document.getElementById('name').value.trim()
+    const ageGroup = document.getElementById('age_group').value
+    const interest = document.getElementById('interest').value.trim()
+    const extraMessage = document.getElementById('message').value.trim()
 
-    const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$
+    const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
     if (!email || !emailPattern.test(email)) {
       messageDiv.textContent = 'Please enter a valid email.'
       return
@@ -21,11 +25,18 @@ document.addEventListener('DOMContentLoaded', () => {
     submitBtn.disabled = true
     submitBtn.innerText = 'Submitting...'
 
-    let error
+    let data, error
     try {
-      ;({ error } = await supabase
+      ;({ data, error } = await supabase
         .from('email_captures')
-        .insert({ email }))
+        .insert({
+          name,
+          age_group: ageGroup,
+          interest,
+          message: extraMessage,
+          email,
+        })
+        .select())
     } catch (e) {
       error = e
     }
@@ -39,6 +50,7 @@ document.addEventListener('DOMContentLoaded', () => {
       return
     }
 
+    console.log('Form submission stored:', data)
     form.reset()
     formContainer.style.display = 'none'
     successMessage.style.display = 'block'

--- a/index.html
+++ b/index.html
@@ -84,7 +84,7 @@
   <div id="searchResults" style="margin-top: 10px;"></div>
 
   <div style="margin-top: 20px;">
-    <input type="email" id="email" placeholder="Email" />
+    <input type="email" id="auth-email" placeholder="Email" />
     <input type="password" id="password" placeholder="Password" />
     <button id="signupButton">Sign Up</button>
     <button id="loginButton">Log In</button>
@@ -106,8 +106,8 @@
       </select>
       <input type="text" id="interest" placeholder="What are you most interested in?" />
       <textarea id="message" placeholder="Anything else to share?"></textarea>
-      <label for="email">Email:</label>
-      <input type="email" id="email" placeholder="Enter your email" />
+      <label for="waitlist-email">Email:</label>
+      <input type="email" id="waitlist-email" placeholder="Enter your email" />
       <button id="submitBtn" type="submit">Join Waitlist</button>
     </form>
     <div id="form-message"></div>

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ document.addEventListener('DOMContentLoaded', () => {
     button.addEventListener('click', testSupabase)
   }
 
-  const emailInput = document.getElementById('email')
+  const emailInput = document.getElementById('auth-email')
   const passwordInput = document.getElementById('password')
   const resultText = document.getElementById('authResult')
 


### PR DESCRIPTION
## Summary
- fix ID collision between auth and waitlist email inputs
- send full waitlist form payload to `email_captures` and show success message
- reference new auth email input in login logic

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68919f2b7cdc83298c97f0a7f8862ca9