### PR TITLE
feat: integrate Supabase subscription backend

### DIFF
--- a/app/api/subscribe/route.ts
+++ b/app/api/subscribe/route.ts
@@ -1,0 +1,49 @@
+import { NextResponse } from 'next/server'
+import { createClient } from '@supabase/supabase-js'
+
+const supabaseUrl = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL
+const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+
+if (!supabaseUrl || !supabaseKey) {
+  throw new Error('Supabase URL and service role key must be provided')
+}
+
+const supabase = createClient(supabaseUrl, supabaseKey)
+
+export async function POST(request: Request) {
+  try {
+    const { email, interests } = await request.json()
+
+    const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+    if (!email || !emailPattern.test(email)) {
+      return NextResponse.json(
+        { success: false, message: 'Invalid email.' },
+        { status: 400 }
+      )
+    }
+
+    if (!Array.isArray(interests)) {
+      return NextResponse.json(
+        { success: false, message: 'Interests must be an array.' },
+        { status: 400 }
+      )
+    }
+
+    const { error } = await supabase.from('subscribers').insert({
+      email,
+      interests,
+      subscribed_at: new Date().toISOString(),
+    })
+
+    if (error) {
+      throw error
+    }
+
+    return NextResponse.json({ success: true, message: 'Subscription successful.' })
+  } catch (err: any) {
+    return NextResponse.json(
+      { success: false, message: err.message || 'Unknown error.' },
+      { status: 500 }
+    )
+  }
+}


### PR DESCRIPTION
## Summary
- add API route for handling subscriptions via Supabase
- enhance subscription form with interest options and success/error messaging

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6891a0a22ed08329b915f364b07d6fe6