### PR TITLE
feat: add subscription admin client and schema

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,2 +1,4 @@
+SUPABASE_URL=https://your-project-url.supabase.co
+SUPABASE_SERVICE_ROLE_KEY=your-key-here
 NEXT_PUBLIC_SUPABASE_URL=
 NEXT_PUBLIC_SUPABASE_ANON_KEY=

--- a/app/api/subscribe/route.ts
+++ b/app/api/subscribe/route.ts
@@ -1,14 +1,5 @@
 import { NextResponse } from 'next/server'
-import { createClient } from '@supabase/supabase-js'
-
-const supabaseUrl = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL
-const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY
-
-if (!supabaseUrl || !supabaseKey) {
-  throw new Error('Supabase URL and service role key must be provided')
-}
-
-const supabase = createClient(supabaseUrl, supabaseKey)
+import { supabaseAdmin } from '../../../lib/supabaseAdmin'
 
 export async function POST(request: Request) {
   try {
@@ -29,7 +20,7 @@ export async function POST(request: Request) {
       )
     }
 
-    const { error } = await supabase.from('subscribers').insert({
+    const { error } = await supabaseAdmin.from('subscribers').insert({
       email,
       interests,
       subscribed_at: new Date().toISOString(),

--- a/create_subscribers_table.sql
+++ b/create_subscribers_table.sql
@@ -1,0 +1,20 @@
+create extension if not exists "uuid-ossp";
+
+create table if not exists public.subscribers (
+  id uuid primary key default uuid_generate_v4(),
+  email text unique not null,
+  interests jsonb,
+  subscribed_at timestamptz default now()
+);
+
+alter table public.subscribers enable row level security;
+
+create policy "Allow insert for service role" on public.subscribers
+  for insert
+  using (auth.role() = 'service_role')
+  with check (auth.role() = 'service_role');
+
+create policy "Allow insert for authenticated users" on public.subscribers
+  for insert
+  to authenticated
+  with check (true);

--- a/lib/supabaseAdmin.ts
+++ b/lib/supabaseAdmin.ts
@@ -1,0 +1,10 @@
+import { createClient } from '@supabase/supabase-js'
+
+const supabaseUrl = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL
+const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+
+if (!supabaseUrl || !serviceRoleKey) {
+  throw new Error('Supabase URL and service role key must be provided')
+}
+
+export const supabaseAdmin = createClient(supabaseUrl, serviceRoleKey)

--- a/pages/api/subscribe.ts
+++ b/pages/api/subscribe.ts
@@ -1,28 +1,46 @@
-import type { NextApiRequest, NextApiResponse } from 'next';
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { supabaseAdmin } from '../../lib/supabaseAdmin'
 
-export default function handler(req: NextApiRequest, res: NextApiResponse) {
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
   if (req.method !== 'POST') {
-    return res.status(400).json({ error: 'Only POST requests are allowed' });
+    return res.status(400).json({ error: 'Only POST requests are allowed' })
   }
 
   try {
-    const { name, email } = req.body as { name?: string; email?: string };
-
-    if (!name || !email) {
-      return res.status(400).json({ error: 'Name and email are required' });
+    const { email, interests } = req.body as {
+      email?: string
+      interests?: string[]
     }
 
-    const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-    if (!emailPattern.test(email)) {
-      return res.status(400).json({ error: 'Invalid email format' });
+    const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+    if (!email || !emailPattern.test(email)) {
+      return res.status(400).json({ error: 'Valid email is required' })
     }
 
-    console.log('New subscription:', { name, email });
+    if (interests && !Array.isArray(interests)) {
+      return res
+        .status(400)
+        .json({ error: 'Interests must be an array of strings' })
+    }
 
-    return res.status(200).json({ message: 'Subscription received' });
+    const { error } = await supabaseAdmin.from('subscribers').insert({
+      email,
+      interests: interests || [],
+      subscribed_at: new Date().toISOString(),
+    })
+
+    if (error) {
+      console.error('Supabase insert error:', error)
+      return res.status(500).json({ error: 'Failed to save subscription' })
+    }
+
+    return res.status(200).json({ message: 'Subscription received' })
   } catch (err) {
-    console.error('Subscription error:', err);
-    return res.status(400).json({ error: 'Invalid request payload' });
+    console.error('Subscription error:', err)
+    return res.status(400).json({ error: 'Invalid request payload' })
   }
 }
 


### PR DESCRIPTION
## Summary
- add SQL schema and policies for `subscribers` table
- use service-role client for secure inserts
- document required Supabase env vars

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6891a1cfd6d88329b8c3c44f061ded81