### PR TITLE
feat: add CORS support for subscription API

### DIFF
--- a/pages/api/subscribe.ts
+++ b/pages/api/subscribe.ts
@@ -5,8 +5,17 @@ export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse
 ) {
+  // Enable CORS for cross-domain requests
+  res.setHeader('Access-Control-Allow-Origin', '*')
+  res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS')
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type')
+
+  if (req.method === 'OPTIONS') {
+    return res.status(200).end()
+  }
+
   if (req.method !== 'POST') {
-    return res.status(400).json({ error: 'Only POST requests are allowed' })
+    return res.status(405).json({ error: 'Only POST requests are allowed' })
   }
 
   try {


### PR DESCRIPTION
## Summary
- add CORS headers and OPTIONS handling for subscription API route

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6891a31a368083298b1364594d477379