### PR TITLE
chore: configure hardhat to use local caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .env.local
 node_modules/
+artifacts/
+cache/

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -7,6 +7,10 @@ module.exports = {
       settings: {},
     }],
   },
+  paths: {
+    cache: "./cache",
+    artifacts: "./artifacts",
+  },
   networks: {
     localhost: {
       url: "http://127.0.0.1:8545",


### PR DESCRIPTION
## Summary
- add local cache and artifact paths in Hardhat configuration
- ignore Hardhat build output directories

## Testing
- `npx hardhat node`
- `npx hardhat compile` *(fails: Error HH502: Couldn't download compiler version list)*
- `npx hardhat run scripts/deploy.js --network localhost` *(fails: Error HH502: Couldn't download compiler version list)*

------
https://chatgpt.com/codex/tasks/task_e_6892eda726c483298862e953d66bf0f2