### PR TITLE
Pin Solidity compiler to 0.8.18 and use local solc

### DIFF
--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -1,19 +1,11 @@
 require("@nomicfoundation/hardhat-toolbox");
 
 module.exports = {
-  solidity: {
-    compilers: [{
-      version: "0.8.18",
-      settings: {},
-    }],
-  },
-  paths: {
-    cache: "./cache",
-    artifacts: "./artifacts",
-  },
+  solidity: "0.8.18",
   networks: {
     localhost: {
       url: "http://127.0.0.1:8545",
     },
   },
 };
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,13 @@
       "version": "1.0.0",
       "dependencies": {
         "@openzeppelin/contracts": "^4.9.5",
-        "@supabase/supabase-js": "^2.53.0",
-        "solc": "^0.8.18"
+        "@supabase/supabase-js": "^2.53.0"
       },
       "devDependencies": {
         "@nomicfoundation/hardhat-toolbox": "^6.1.0",
         "hardhat": "^2.26.2",
-        "lite-server": "^2.6.1"
+        "lite-server": "^2.6.1",
+        "solc": "^0.8.18"
       }
     },
     "node_modules/@adraffy/ens-normalize": {
@@ -2959,6 +2959,7 @@
       "version": "1.2.9",
       "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.9.tgz",
       "integrity": "sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/command-line-args": {
@@ -4135,6 +4136,7 @@
       "version": "1.15.11",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
       "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -5549,6 +5551,7 @@
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
       "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -5943,6 +5946,7 @@
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
       "integrity": "sha512-S3UwM3yj5mtUSEfP41UZmt/0SCoVYUcU1rkXv+BQ5Ig8ndL4sPoJNBUJERafdPb5jjHJGuMgytgKvKIf58XNBw==",
+      "dev": true,
       "engines": {
         "node": ">= 0.10.0"
       }
@@ -6544,6 +6548,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -7961,6 +7966,7 @@
       "version": "0.8.18",
       "resolved": "https://registry.npmjs.org/solc/-/solc-0.8.18.tgz",
       "integrity": "sha512-wVAa2Y3BYd64Aby5LsgS3g6YC2NvZ3bJ+A8TAIAukfVuQb3AjyGrLZpyxQk5YLn14G35uZtSnIgHEpab9klOLQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "command-exists": "^1.2.8",
@@ -7982,6 +7988,7 @@
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
       "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -7991,6 +7998,7 @@
       "version": "5.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
       "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver"
@@ -8497,6 +8505,7 @@
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
       "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "os-tmpdir": "~1.0.2"

--- a/package.json
+++ b/package.json
@@ -11,11 +11,11 @@
   "devDependencies": {
     "@nomicfoundation/hardhat-toolbox": "^6.1.0",
     "hardhat": "^2.26.2",
-    "lite-server": "^2.6.1"
+    "lite-server": "^2.6.1",
+    "solc": "^0.8.18"
   },
   "dependencies": {
     "@openzeppelin/contracts": "^4.9.5",
-    "@supabase/supabase-js": "^2.53.0",
-    "solc": "^0.8.18"
+    "@supabase/supabase-js": "^2.53.0"
   }
 }


### PR DESCRIPTION
## Summary
- install local `solc` 0.8.18
- pin Hardhat to Solidity 0.8.18 and configure localhost network

## Testing
- `npm install solc@0.8.18 --save-dev`
- `npx hardhat clean`
- `npx hardhat compile` *(fails: Couldn't download compiler version list)*
- `npx hardhat node`
- `npx hardhat run scripts/deploy.js --network localhost` *(fails: Couldn't download compiler version list)*

------
https://chatgpt.com/codex/tasks/task_e_6892f19a64bc832997b1dbbe19875ed8