### PR TITLE
Use local Solidity compiler to bypass Hardhat HH502

### DIFF
--- a/hardhat-compile-solc/index.js
+++ b/hardhat-compile-solc/index.js
@@ -1,0 +1,15 @@
+const { subtask } = require("hardhat/config");
+const { TASK_COMPILE_SOLIDITY_GET_SOLC_BUILD } = require("hardhat/builtin-tasks/task-names");
+
+subtask(TASK_COMPILE_SOLIDITY_GET_SOLC_BUILD, async (args, hre, runSuper) => {
+  const solcConfig = hre.config.solc;
+  if (solcConfig && solcConfig.compilerPath) {
+    return {
+      compilerPath: solcConfig.compilerPath,
+      isSolcJs: true,
+      version: solcConfig.version,
+      longVersion: solcConfig.version,
+    };
+  }
+  return runSuper(args);
+});

--- a/hardhat-compile-solc/package.json
+++ b/hardhat-compile-solc/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "hardhat-compile-solc",
+  "version": "1.0.0",
+  "main": "index.js"
+}

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -1,11 +1,30 @@
 require("@nomicfoundation/hardhat-toolbox");
+require("hardhat-compile-solc");
+
+const solcPath = require.resolve("solc/soljson.js");
 
 module.exports = {
-  solidity: "0.8.18",
+  solidity: {
+    compilers: [
+      {
+        version: "0.8.18",
+        settings: {
+          optimizer: {
+            enabled: true,
+            runs: 200,
+          },
+        },
+      },
+    ],
+  },
   networks: {
     localhost: {
       url: "http://127.0.0.1:8545",
     },
+  },
+  solc: {
+    version: "0.8.18",
+    compilerPath: solcPath,
   },
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,9 +14,14 @@
       "devDependencies": {
         "@nomicfoundation/hardhat-toolbox": "^6.1.0",
         "hardhat": "^2.26.2",
+        "hardhat-compile-solc": "file:hardhat-compile-solc",
         "lite-server": "^2.6.1",
         "solc": "^0.8.18"
       }
+    },
+    "hardhat-compile-solc": {
+      "version": "1.0.0",
+      "dev": true
     },
     "node_modules/@adraffy/ens-normalize": {
       "version": "1.10.1",
@@ -4698,6 +4703,10 @@
           "optional": true
         }
       }
+    },
+    "node_modules/hardhat-compile-solc": {
+      "resolved": "hardhat-compile-solc",
+      "link": true
     },
     "node_modules/hardhat-gas-reporter": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "@nomicfoundation/hardhat-toolbox": "^6.1.0",
     "hardhat": "^2.26.2",
     "lite-server": "^2.6.1",
-    "solc": "^0.8.18"
+    "solc": "^0.8.18",
+    "hardhat-compile-solc": "file:hardhat-compile-solc"
   },
   "dependencies": {
     "@openzeppelin/contracts": "^4.9.5",


### PR DESCRIPTION
## Summary
- use local solc 0.8.18 via hardhat-compile-solc plugin
- configure Hardhat to optimize contracts and reference local binary
- document plugin dependency for offline compilation

## Testing
- `npx hardhat clean`
- `npx hardhat compile`
- `npm test`
- `npx hardhat node` *(separate run to verify startup)*
- `npx hardhat run scripts/deploy.js --network localhost`


------
https://chatgpt.com/codex/tasks/task_e_6892f415ca7083299d2aca21fe2c921b