### PR TITLE
Use local solc for Hardhat compilation

### DIFF
--- a/hardhat-compile-solc/index.js
+++ b/hardhat-compile-solc/index.js
@@ -1,15 +1,24 @@
+const path = require("path");
 const { subtask } = require("hardhat/config");
 const { TASK_COMPILE_SOLIDITY_GET_SOLC_BUILD } = require("hardhat/builtin-tasks/task-names");
 
-subtask(TASK_COMPILE_SOLIDITY_GET_SOLC_BUILD, async (args, hre, runSuper) => {
-  const solcConfig = hre.config.solc;
-  if (solcConfig && solcConfig.compilerPath) {
-    return {
-      compilerPath: solcConfig.compilerPath,
-      isSolcJs: true,
-      version: solcConfig.version,
-      longVersion: solcConfig.version,
-    };
-  }
-  return runSuper(args);
-});
+function useLocalSolc() {
+  subtask(TASK_COMPILE_SOLIDITY_GET_SOLC_BUILD).setAction(
+    async (args, hre, runSuper) => {
+      if (args.solcVersion === "0.8.18") {
+        const compilerPath = path.resolve(__dirname, "../node_modules/solc/soljson.js");
+        return {
+          compilerPath,
+          isSolcJs: true,
+          version: "0.8.18",
+          longVersion: "0.8.18",
+        };
+      }
+      return runSuper(args);
+    }
+  );
+}
+
+useLocalSolc();
+
+module.exports = useLocalSolc;


### PR DESCRIPTION
## Summary
- override Hardhat solc build lookup to use local solc v0.8.18

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6892f67afb588329a94fa0a09d28788a