### PR TITLE
Connect to Alchemy Amoy testnet and print latest block number

### DIFF
--- a/getLatestBlock.mjs
+++ b/getLatestBlock.mjs
@@ -8,8 +8,13 @@ const settings = {
 const alchemy = new Alchemy(settings);
 
 async function getLatestBlock() {
-  const block = await alchemy.core.getBlockNumber();
-  console.log("Latest Block Number:", block);
+  try {
+    console.log("Connecting to Alchemy Amoy testnet...");
+    const block = await alchemy.core.getBlockNumber();
+    console.log("Latest Block Number:", block);
+  } catch (err) {
+    console.error("Failed to fetch latest block number:", err);
+  }
 }
 
 getLatestBlock();


### PR DESCRIPTION
## Summary
- add explicit logging when connecting to Alchemy Amoy and retrieving latest block number
- handle errors from alchemy-sdk when request fails

## Testing
- `ping -c 2 polygon-amoy.g.alchemy.com` (fails: Network is unreachable)
- `node getLatestBlock.mjs` (fails: ENETUNREACH)


------
https://chatgpt.com/codex/tasks/task_e_68931b60b3348329bccaec72bc5db755