### PR TITLE
Store subscriptions in Supabase

### DIFF
--- a/pages/api/subscribe.ts
+++ b/pages/api/subscribe.ts
@@ -1,5 +1,14 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
-import { supabaseAdmin } from '../../lib/supabaseAdmin'
+import { createClient } from '@supabase/supabase-js'
+
+const supabaseUrl = process.env.SUPABASE_URL
+const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+
+if (!supabaseUrl || !serviceRoleKey) {
+  throw new Error('Supabase credentials are missing')
+}
+
+const supabase = createClient(supabaseUrl, serviceRoleKey)
 
 export default async function handler(
   req: NextApiRequest,
@@ -21,7 +30,7 @@ export default async function handler(
   try {
     const { email, interests } = req.body as {
       email?: string
-      interests?: string[]
+      interests?: string | string[]
     }
 
     const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
@@ -29,21 +38,30 @@ export default async function handler(
       return res.status(400).json({ error: 'Valid email is required' })
     }
 
-    if (interests && !Array.isArray(interests)) {
-      return res
-        .status(400)
-        .json({ error: 'Interests must be an array of strings' })
+    const { data: existing, error: existingError } = await supabase
+      .from('subscribers')
+      .select('id')
+      .eq('email', email)
+      .maybeSingle()
+
+    if (existingError) {
+      console.error('Supabase select error:', existingError)
+      return res.status(500).json({ error: existingError.message })
     }
 
-    const { error } = await supabaseAdmin.from('subscribers').insert({
+    if (existing) {
+      return res.status(200).json({ message: 'Email already subscribed' })
+    }
+
+    const { error: insertError } = await supabase.from('subscribers').insert({
       email,
-      interests: interests || [],
-      subscribed_at: new Date().toISOString(),
+      interests: interests || null,
+      created_at: new Date().toISOString(),
     })
 
-    if (error) {
-      console.error('Supabase insert error:', error)
-      return res.status(500).json({ error: 'Failed to save subscription' })
+    if (insertError) {
+      console.error('Supabase insert error:', insertError)
+      return res.status(500).json({ error: insertError.message })
     }
 
     return res.status(200).json({ message: 'Subscription received' })


### PR DESCRIPTION
## Summary
- Initialize Supabase client in API route using service role key
- Validate and deduplicate incoming subscription emails
- Persist new subscriber records with optional interests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68937af5a80483298a7744c3c427ec45