### PR TITLE
Add admin subscriber dashboard with search and CSV export

### DIFF
--- a/components/AdminSubscriberTable.tsx
+++ b/components/AdminSubscriberTable.tsx
@@ -1,0 +1,79 @@
+export interface Subscriber {
+  id: string
+  email: string
+  interests: string | null
+  created_at: string
+  source: string | null
+}
+
+interface TableProps {
+  subscribers: Subscriber[]
+  page: number
+  total: number
+  pageSize: number
+  onPageChange: (page: number) => void
+  onDelete?: (id: string) => void
+}
+
+export default function AdminSubscriberTable({ subscribers, page, total, pageSize, onPageChange, onDelete }: TableProps) {
+  if (subscribers.length === 0) {
+    return <div>No subscribers found.</div>
+  }
+
+  return (
+    <div>
+      <div className="overflow-x-auto">
+        <table className="min-w-full border-collapse">
+          <thead>
+            <tr>
+              <th className="border px-4 py-2 text-left">Email</th>
+              <th className="border px-4 py-2 text-left">Interest</th>
+              <th className="border px-4 py-2 text-left">Created Date</th>
+              <th className="border px-4 py-2 text-left">Source</th>
+              {onDelete && <th className="border px-4 py-2 text-left">Actions</th>}
+            </tr>
+          </thead>
+          <tbody>
+            {subscribers.map((s) => (
+              <tr key={s.id}>
+                <td className="border px-4 py-2">{s.email}</td>
+                <td className="border px-4 py-2">{Array.isArray(s.interests) ? s.interests.join(', ') : s.interests || ''}</td>
+                <td className="border px-4 py-2">{new Date(s.created_at).toLocaleString()}</td>
+                <td className="border px-4 py-2">{s.source || ''}</td>
+                {onDelete && (
+                  <td className="border px-4 py-2">
+                    <button
+                      onClick={() => onDelete(s.id)}
+                      className="px-2 py-1 bg-red-500 text-white rounded"
+                    >
+                      Delete
+                    </button>
+                  </td>
+                )}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <div className="mt-4 flex items-center gap-4">
+        <button
+          onClick={() => onPageChange(Math.max(1, page - 1))}
+          disabled={page === 1}
+          className="px-4 py-2 bg-gray-200 rounded disabled:opacity-50"
+        >
+          Previous
+        </button>
+        <span>
+          Page {page} of {Math.max(1, Math.ceil(total / pageSize))} (Total: {total})
+        </span>
+        <button
+          onClick={() => onPageChange(page + 1)}
+          disabled={page * pageSize >= total}
+          className="px-4 py-2 bg-gray-200 rounded disabled:opacity-50"
+        >
+          Next
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/components/SearchBar.tsx
+++ b/components/SearchBar.tsx
@@ -1,0 +1,26 @@
+import { useState, useEffect } from 'react'
+
+interface SearchBarProps {
+  onSearch: (value: string) => void
+  placeholder?: string
+  delay?: number
+}
+
+export default function SearchBar({ onSearch, placeholder = 'Search...', delay = 300 }: SearchBarProps) {
+  const [value, setValue] = useState('')
+
+  useEffect(() => {
+    const handler = setTimeout(() => onSearch(value), delay)
+    return () => clearTimeout(handler)
+  }, [value, delay, onSearch])
+
+  return (
+    <input
+      type="text"
+      value={value}
+      onChange={(e) => setValue(e.target.value)}
+      placeholder={placeholder}
+      className="px-2 py-1 border rounded w-full md:w-64"
+    />
+  )
+}

--- a/pages/admin/subscribers.tsx
+++ b/pages/admin/subscribers.tsx
@@ -2,53 +2,42 @@ import { useEffect, useState } from 'react'
 import { useRouter } from 'next/router'
 import { supabase } from '../../supabaseClient.js'
 import { supabaseAdmin } from '../../lib/supabaseAdmin'
+import SearchBar from '../../components/SearchBar'
+import AdminSubscriberTable, { Subscriber } from '../../components/AdminSubscriberTable'
+import { exportToCsv } from '../../utils/exportCsv'
+import { isAdmin } from '../../utils/isAdmin'
 
-interface Subscriber {
-  id: string
-  email: string
-  interests: string | null
-  created_at: string
-}
-
-export default function Subscribers() {
+export default function SubscribersPage() {
   const [subs, setSubs] = useState<Subscriber[]>([])
   const [loading, setLoading] = useState(true)
   const [page, setPage] = useState(1)
   const [total, setTotal] = useState(0)
   const [search, setSearch] = useState('')
-  const [debouncedSearch, setDebouncedSearch] = useState('')
   const router = useRouter()
 
   const PAGE_SIZE = 10
 
   useEffect(() => {
-    const handler = setTimeout(() => setDebouncedSearch(search), 300)
-    return () => clearTimeout(handler)
-  }, [search])
+    async function protect() {
+      const { data: { user } } = await supabase.auth.getUser()
+      if (!user || !isAdmin(user.email)) {
+        router.replace('/')
+        return
+      }
+    }
+    protect()
+  }, [router])
 
   useEffect(() => {
     async function load() {
-      const {
-        data: { user },
-      } = await supabase.auth.getUser()
-      const allowed = (process.env.ALLOWED_ADMINS || '')
-        .split(',')
-        .map((e) => e.trim())
-        .filter(Boolean)
-      if (!user?.email || !allowed.includes(user.email)) {
-        router.push('/')
-        return
-      }
       setLoading(true)
       let query = supabaseAdmin
         .from('subscribers')
-        .select('id,email,interests,created_at', { count: 'exact' })
+        .select('id,email,interests,created_at,source', { count: 'exact' })
         .order('created_at', { ascending: false })
         .range((page - 1) * PAGE_SIZE, page * PAGE_SIZE - 1)
-      if (debouncedSearch) {
-        query = query.or(
-          `email.ilike.%${debouncedSearch}%,interests.ilike.%${debouncedSearch}%`
-        )
+      if (search) {
+        query = query.or(`email.ilike.%${search}%,interests.ilike.%${search}%`)
       }
       const { data, count } = await query
       setSubs(data || [])
@@ -56,100 +45,44 @@ export default function Subscribers() {
       setLoading(false)
     }
     load()
-  }, [router, page, debouncedSearch])
+  }, [page, search])
 
-  if (loading) return <div>Loading...</div>
-
-  const exportCsv = () => {
-    const headers = ['Email', 'Interests', 'Created At']
+  const handleExport = () => {
+    const headers = ['Email', 'Interest', 'Created Date', 'Source']
     const rows = subs.map((s) => [
       s.email,
       Array.isArray(s.interests) ? s.interests.join(', ') : s.interests || '',
       new Date(s.created_at).toISOString(),
+      s.source || '',
     ])
-    const csv = [headers, ...rows]
-      .map((row) =>
-        row
-          .map((field) => `"${String(field).replace(/"/g, '""')}"`)
-          .join(',')
-      )
-      .join('\n')
-    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' })
-    const url = URL.createObjectURL(blob)
-    const link = document.createElement('a')
-    link.href = url
-    link.setAttribute('download', 'subscribers-export.csv')
-    document.body.appendChild(link)
-    link.click()
-    document.body.removeChild(link)
-    URL.revokeObjectURL(url)
+    exportToCsv('subscribers-export.csv', headers, rows)
   }
+
+  const handleDelete = async (id: string) => {
+    await supabaseAdmin.from('subscribers').delete().eq('id', id)
+    setSubs((curr) => curr.filter((s) => s.id !== id))
+    setTotal((t) => t - 1)
+  }
+
+  if (loading) return <div>Loading...</div>
 
   return (
     <main className="p-4">
       <h1 className="text-2xl mb-4">Subscribers</h1>
-      <div className="mb-4 flex items-center gap-4">
-        <input
-          type="text"
-          placeholder="Search by email or interest"
-          value={search}
-          onChange={(e) => {
-            setSearch(e.target.value)
-            setPage(1)
-          }}
-          className="px-2 py-1 border rounded"
-        />
-        <button
-          onClick={exportCsv}
-          className="px-4 py-2 bg-blue-500 text-white rounded"
-        >
+      <div className="mb-4 flex flex-col md:flex-row items-start md:items-center gap-4">
+        <SearchBar onSearch={(val) => { setSearch(val); setPage(1) }} placeholder="Search by email or interest" />
+        <button onClick={handleExport} className="px-4 py-2 bg-blue-500 text-white rounded">
           Export CSV
         </button>
       </div>
-      {subs.length === 0 ? (
-        <div>No subscribers found.</div>
-      ) : (
-        <>
-          <table className="min-w-full border-collapse">
-          <thead>
-            <tr>
-              <th className="border px-4 py-2 text-left">Email</th>
-              <th className="border px-4 py-2 text-left">Interests</th>
-              <th className="border px-4 py-2 text-left">Created At</th>
-            </tr>
-          </thead>
-          <tbody>
-            {subs.map((s) => (
-              <tr key={s.id}>
-                <td className="border px-4 py-2">{s.email}</td>
-                <td className="border px-4 py-2">{Array.isArray(s.interests) ? s.interests.join(', ') : s.interests || ''}</td>
-                <td className="border px-4 py-2">{new Date(s.created_at).toLocaleString()}</td>
-              </tr>
-            ))}
-          </tbody>
-          </table>
-          <div className="mt-4 flex items-center gap-4">
-            <button
-              onClick={() => setPage((p) => Math.max(1, p - 1))}
-              disabled={page === 1}
-              className="px-4 py-2 bg-gray-200 rounded disabled:opacity-50"
-            >
-              Previous
-            </button>
-            <span>
-              Page {page} of {Math.max(1, Math.ceil(total / PAGE_SIZE))} (Total: {total})
-            </span>
-            <button
-              onClick={() => setPage((p) => p + 1)}
-              disabled={page * PAGE_SIZE >= total}
-              className="px-4 py-2 bg-gray-200 rounded disabled:opacity-50"
-            >
-              Next
-            </button>
-          </div>
-        </>
-      )}
+      <AdminSubscriberTable
+        subscribers={subs}
+        page={page}
+        total={total}
+        pageSize={PAGE_SIZE}
+        onPageChange={setPage}
+        onDelete={handleDelete}
+      />
     </main>
   )
 }
-

--- a/utils/exportCsv.ts
+++ b/utils/exportCsv.ts
@@ -1,0 +1,14 @@
+export function exportToCsv(filename: string, headers: string[], rows: (string | number | null | undefined)[][]) {
+  const csv = [headers, ...rows]
+    .map(row => row.map(field => `"${String(field ?? '').replace(/"/g, '""')}"`).join(','))
+    .join('\n')
+  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' })
+  const url = URL.createObjectURL(blob)
+  const link = document.createElement('a')
+  link.href = url
+  link.setAttribute('download', filename)
+  document.body.appendChild(link)
+  link.click()
+  document.body.removeChild(link)
+  URL.revokeObjectURL(url)
+}

--- a/utils/isAdmin.ts
+++ b/utils/isAdmin.ts
@@ -1,0 +1,7 @@
+export function isAdmin(email?: string | null): boolean {
+  const allowed = (process.env.ALLOWED_ADMINS || '')
+    .split(',')
+    .map(e => e.trim())
+    .filter(Boolean)
+  return email ? allowed.includes(email) : false
+}


### PR DESCRIPTION
## Summary
- refactor admin subscribers page to use reusable components and utilities
- add SearchBar and AdminSubscriberTable components with pagination and delete option
- include CSV export and admin email gate via ALLOWED_ADMINS

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689383e6840c8329923fd8046afb5a6e