### PR TITLE
Simplify admin subscribers page

### DIFF
--- a/components/SearchBar.tsx
+++ b/components/SearchBar.tsx
@@ -1,26 +1,17 @@
-import { useState, useEffect } from 'react'
-
-interface SearchBarProps {
-  onSearch: (value: string) => void
-  placeholder?: string
-  delay?: number
+interface Props {
+  search: string
+  setSearch: (value: string) => void
 }
 
-export default function SearchBar({ onSearch, placeholder = 'Search...', delay = 300 }: SearchBarProps) {
-  const [value, setValue] = useState('')
-
-  useEffect(() => {
-    const handler = setTimeout(() => onSearch(value), delay)
-    return () => clearTimeout(handler)
-  }, [value, delay, onSearch])
-
+export default function SearchBar({ search, setSearch }: Props) {
   return (
     <input
       type="text"
-      value={value}
-      onChange={(e) => setValue(e.target.value)}
-      placeholder={placeholder}
-      className="px-2 py-1 border rounded w-full md:w-64"
+      placeholder="Search by email or interest…"
+      value={search}
+      onChange={(e) => setSearch(e.target.value)}
+      className="w-full p-2 border border-gray-300 rounded mb-4"
     />
   )
 }
+

--- a/components/SubscriberTable.tsx
+++ b/components/SubscriberTable.tsx
@@ -1,0 +1,70 @@
+interface Subscriber {
+  email: string
+  interest?: string | null
+  created_at: string
+}
+
+interface Props {
+  subscribers: Subscriber[]
+  page: number
+  setPage: (p: number) => void
+  perPage: number
+}
+
+export default function SubscriberTable({ subscribers, page, setPage, perPage }: Props) {
+  const totalPages = Math.ceil(subscribers.length / perPage)
+
+  const visible = subscribers.slice((page - 1) * perPage, page * perPage)
+
+  return (
+    <>
+      <table className="w-full mb-4">
+        <thead>
+          <tr>
+            <th className="text-left p-2 border-b">Email</th>
+            <th className="text-left p-2 border-b">Interest</th>
+            <th className="text-left p-2 border-b">Created</th>
+          </tr>
+        </thead>
+        <tbody>
+          {visible.length === 0 ? (
+            <tr>
+              <td colSpan={3} className="text-center p-4">
+                No subscribers found
+              </td>
+            </tr>
+          ) : (
+            visible.map((sub, i) => (
+              <tr key={i}>
+                <td className="p-2 border-b">{sub.email}</td>
+                <td className="p-2 border-b">{sub.interest}</td>
+                <td className="p-2 border-b">{new Date(sub.created_at).toLocaleDateString()}</td>
+              </tr>
+            ))
+          )}
+        </tbody>
+      </table>
+
+      {totalPages > 1 && (
+        <div className="flex gap-2 mb-4">
+          <button
+            disabled={page === 1}
+            onClick={() => setPage(page - 1)}
+            className="px-2 py-1 border rounded disabled:opacity-50"
+          >
+            Prev
+          </button>
+          <span className="px-2 py-1">{page} / {totalPages}</span>
+          <button
+            disabled={page === totalPages}
+            onClick={() => setPage(page + 1)}
+            className="px-2 py-1 border rounded disabled:opacity-50"
+          >
+            Next
+          </button>
+        </div>
+      )}
+    </>
+  )
+}
+

--- a/utils/exportCsv.ts
+++ b/utils/exportCsv.ts
@@ -1,14 +1,15 @@
-export function exportToCsv(filename: string, headers: string[], rows: (string | number | null | undefined)[][]) {
-  const csv = [headers, ...rows]
-    .map(row => row.map(field => `"${String(field ?? '').replace(/"/g, '""')}"`).join(','))
-    .join('\n')
-  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' })
-  const url = URL.createObjectURL(blob)
+export function exportCsv(data: any[]) {
+  const header = Object.keys(data[0] || {}).join(',')
+  const rows = data.map(row =>
+    Object.values(row)
+      .map(val => `"${String(val).replace(/"/g, '""')}"`)
+      .join(',')
+  )
+  const csvContent = [header, ...rows].join('\n')
+  const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' })
   const link = document.createElement('a')
-  link.href = url
-  link.setAttribute('download', filename)
-  document.body.appendChild(link)
+  link.href = URL.createObjectURL(blob)
+  link.download = 'subscribers.csv'
   link.click()
-  document.body.removeChild(link)
-  URL.revokeObjectURL(url)
 }
+

--- a/utils/isAdmin.ts
+++ b/utils/isAdmin.ts
@@ -1,7 +1,6 @@
-export function isAdmin(email?: string | null): boolean {
-  const allowed = (process.env.ALLOWED_ADMINS || '')
-    .split(',')
-    .map(e => e.trim())
-    .filter(Boolean)
-  return email ? allowed.includes(email) : false
+const allowed = (process.env.NEXT_PUBLIC_ALLOWED_ADMINS || '').split(',')
+
+export function isAdmin(email: string) {
+  return allowed.includes(email)
 }
+


### PR DESCRIPTION
## Summary
- rebuild subscriber admin page with supabase client, search and CSV export
- add lightweight SearchBar and SubscriberTable components
- streamline CSV export and admin check utilities

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68938761beac832984a671696c724c9c