### PR TITLE
chore: track hardhat-compile-solc lockfile

### DIFF
--- a/hardhat-compile-solc/package-lock.json
+++ b/hardhat-compile-solc/package-lock.json
@@ -1,0 +1,12 @@
+{
+  "name": "hardhat-compile-solc",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "hardhat-compile-solc",
+      "version": "1.0.0"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add package-lock for hardhat-compile-solc
## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6894c8056e2883299077ede8422c3270