### PR TITLE
Add SEO metadata and Google Analytics placeholder

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,3 +19,6 @@ STRIPE_SECRET_KEY=sk_test_your_stripe_secret_key_here
 VITE_CONTRACT_ADDRESS=0x742d35Cc6634C0532925a3b8D0C8C8a5C3c3a3B6
 POLYGON_RPC_URL=https://polygon-mainnet.infura.io/v3/your_infura_key
 PRIVATE_KEY=your_wallet_private_key_for_minting
+
+# Google Analytics
+VITE_GA_MEASUREMENT_ID=your_ga_measurement_id

--- a/index.html
+++ b/index.html
@@ -1,14 +1,52 @@
 
 <!DOCTYPE html>
-<html lang='en'>
+<html lang="en">
   <head>
-    <meta charset='UTF-8' />
-    <link rel='icon' type='image/svg+xml' href='/favicon.svg' />
-    <meta name='viewport' content='width=device-width, initial-scale=1.0' />
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/x-icon" href="/favicon.ico" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Naturverse</title>
+    <meta
+      name="description"
+      content="Naturverse is an immersive educational world bridging nature and technology."
+    />
+    <meta
+      name="keywords"
+      content="Naturverse, education, game, nature, technology"
+    />
+    <meta name="author" content="Naturverse" />
+    <meta property="og:title" content="Naturverse" />
+    <meta
+      property="og:description"
+      content="Immersive educational world bridging nature and technology."
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://thenaturverse.com" />
+    <meta property="og:image" content="/logo.png" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Naturverse" />
+    <meta
+      name="twitter:description"
+      content="Immersive educational world bridging nature and technology."
+    />
+    <meta name="twitter:image" content="/logo.png" />
+    <!-- Google Analytics -->
+    <script
+      async
+      src="https://www.googletagmanager.com/gtag/js?id=%VITE_GA_MEASUREMENT_ID%"
+    ></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag() {
+        dataLayer.push(arguments);
+      }
+      gtag("js", new Date());
+      gtag("config", "%VITE_GA_MEASUREMENT_ID%");
+    </script>
   </head>
   <body>
-    <div id='root'></div>
-    <script type='module' src='/src/main.jsx'></script>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add favicon, meta description, and social sharing tags to landing page
- include Google Analytics snippet using `%VITE_GA_MEASUREMENT_ID%`
- document GA measurement ID in `.env.example`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6894d9a4933c8329a96d4dec0f0d66ee